### PR TITLE
fix: moves button margin styles into global styles package

### DIFF
--- a/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_buttons.component.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_buttons.component.scss
@@ -1,0 +1,5 @@
+@use '../1-variables/spacing.variables' as spacing;
+
+.ontario-button {
+	margin: spacing.$spacing-0 (spacing.$spacing-4 + spacing.$spacing-3) spacing.$spacing-5 spacing.$spacing-0;
+}

--- a/packages/ontario-design-system-global-styles/src/styles/scss/theme.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/theme.scss
@@ -45,6 +45,7 @@
 @forward './5-layout/grid.layout';
 
 /*** 6 - Components ***/
+@forward './6-components/buttons.component';
 @forward './6-components/form.component';
 @forward './6-components/labels.component';
 @forward './6-components/text-inputs.component';


### PR DESCRIPTION
DS-1934

- Moves button margin styles into own component file under `global-styles` package