### PR TITLE
refactor: remove ontario-form-group class from web components (DS-2112)

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
@@ -399,7 +399,7 @@ export class OntarioCheckboxes implements Checkboxes {
 	render() {
 		const error = !!this.errorMessage;
 		return (
-			<div class={`ontario-form-group ${error ? 'ontario-input--error' : ''}`}>
+			<div class={error ? 'ontario-input--error' : ''}>
 				<fieldset class="ontario-fieldset" aria-describedby={this.hintTextId}>
 					{this.captionState.getCaption(undefined, !!this.internalHintExpander)}
 					{this.internalHintText && (

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/test/ontario-checkboxes.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/test/ontario-checkboxes.spec.tsx
@@ -10,7 +10,7 @@ describe('ontario-checkbox', () => {
 		expect(page.root).toEqualHtml(`
       <ontario-checkboxes>
         <mock:shadow-root>
-          <div class="ontario-form-group">
+          <div>
             <fieldset class="ontario-fieldset">
               <legend class="ontario-fieldset__legend">
                 <span class="ontario-label__flag">

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
@@ -386,7 +386,7 @@ export class OntarioDateInput {
 		const hintTextId = this.getHintTextId();
 
 		return (
-			<div class="ontario-form-group">
+			<div>
 				<fieldset role="group" class="ontario-fieldset">
 					{this.captionState.getCaption()}
 					{!!hintText && (

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/test/ontario-date-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/test/ontario-date-input.spec.tsx
@@ -10,7 +10,7 @@ describe('ontario-date-input', () => {
 		expect(page.root).toEqualHtml(`
 			<ontario-date-input element-id="date-id-example" language="en">
 				<mock:shadow-root>
-					<div class="ontario-form-group">
+					<div>
 						<fieldset class="ontario-fieldset" role="group">
 							<legend class="ontario-fieldset__legend">
 								Exact date
@@ -78,7 +78,7 @@ describe('ontario-date-input', () => {
 		expect(page.root).toEqualHtml(`
 			<ontario-date-input element-id="date-id-example" caption="{ &quot;captionText&quot;: &quot;Enter Date&quot;, &quot;captionType&quot;: &quot;default&quot; }" date-options="[&quot;month&quot;, &quot;year&quot;]" hint-text="Example 1990 12" max-year="1000" min-year="500" placeholder="{ &quot;day&quot;: &quot;D&quot;, &quot;month&quot;: &quot;M&quot;, &quot;year&quot;: &quot;YY&quot; }" required="true">
 				<mock:shadow-root>
-					<div class="ontario-form-group">
+					<div>
 						<fieldset class="ontario-fieldset" role="group">
 							<legend class="ontario-fieldset__legend">
 								Enter Date

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
@@ -473,7 +473,7 @@ export class OntarioDropdownList implements Dropdown {
 	render() {
 		const error = !!this.errorMessage;
 		return (
-			<div class={`ontario-form-group ${error ? 'ontario-dropdown--error' : ''}`}>
+			<div class={error ? 'ontario-dropdown--error' : ''}>
 				{this.captionState.getCaption(this.getId(), !!this.internalHintExpander)}
 				{this.internalHintText && (
 					<ontario-hint-text

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/test/ontario-dropdown-list.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/test/ontario-dropdown-list.spec.tsx
@@ -11,7 +11,7 @@ describe('ontario-dropdown-list', () => {
 			expect(page.root).toEqualHtml(`
 				<ontario-dropdown-list element-id="dropdown-list" options='[{ "value": "dropdown-option-1", "label": "Option 1" }]'>
 				<mock:shadow-root>
-					<div class="ontario-form-group">
+					<div>
 						<label class="ontario-label" htmlfor="dropdown-list">
 							<span class="ontario-label__flag">
 							(optional)

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.tsx
@@ -88,14 +88,10 @@ export class OntarioFieldset implements Fieldset {
 
 	render() {
 		return (
-			<div class="ontario-form-group">
-				<fieldset class="ontario-fieldset">
-					<legend class={this.getClass()}>
-						{this.legendSize === 'heading' ? <h1>{this.legend}</h1> : this.legend}
-					</legend>
-					<slot />
-				</fieldset>
-			</div>
+			<fieldset class="ontario-fieldset">
+				<legend class={this.getClass()}>{this.legendSize === 'heading' ? <h1>{this.legend}</h1> : this.legend}</legend>
+				<slot />
+			</fieldset>
 		);
 	}
 }

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/test/__snapshots__/ontario-fieldset.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/test/__snapshots__/ontario-fieldset.spec.tsx.snap
@@ -3,16 +3,14 @@
 exports[`ontario-fieldset snapshot should render the expected html 1`] = `
 <ontario-fieldset legend="What is your delivery address?" legend-size="heading">
   <mock:shadow-root>
-    <div class="ontario-form-group">
-      <fieldset class="ontario-fieldset">
-        <legend class="ontario-fieldset__legend ontario-fieldset__legend--heading">
-          <h1>
-            What is your delivery address?
-          </h1>
-        </legend>
-        <slot></slot>
-      </fieldset>
-    </div>
+    <fieldset class="ontario-fieldset">
+      <legend class="ontario-fieldset__legend ontario-fieldset__legend--heading">
+        <h1>
+          What is your delivery address?
+        </h1>
+      </legend>
+      <slot></slot>
+    </fieldset>
   </mock:shadow-root>
 </ontario-fieldset>
 `;

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/test/ontario-fieldset.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/test/ontario-fieldset.spec.tsx
@@ -22,12 +22,10 @@ describe('ontario-fieldset', () => {
 		expect(page.root).toEqualHtml(`
 			<ontario-fieldset legend="What is your delivery address?">
 				<mock:shadow-root>
-					<div class="ontario-form-group">
-						<fieldset class="ontario-fieldset">
-							<legend class="ontario-fieldset__legend">What is your delivery address?</legend>
-							<slot></slot>
-						</fieldset>
-					</div>
+					<fieldset class="ontario-fieldset">
+						<legend class="ontario-fieldset__legend">What is your delivery address?</legend>
+						<slot></slot>
+					</fieldset>
 				</mock:shadow-root>
 			</ontario-fieldset>
 		`);

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
@@ -442,7 +442,7 @@ export class OntarioInput implements TextInput {
 	render() {
 		const error = !!this.errorMessage;
 		return (
-			<div class={`ontario-form-group ${error ? 'ontario-input--error' : ''}`}>
+			<div class={error ? 'ontario-input--error' : ''}>
 				{this.captionState.getCaption(this.getId(), !!this.internalHintExpander)}
 				{this.internalHintText && (
 					<ontario-hint-text

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/__snapshots__/ontario-input.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/__snapshots__/ontario-input.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ontario-input snapshot should render the expected html 1`] = `
 <ontario-input caption="{&quot;captionText&quot;: &quot;Ontario Input&quot;}" element-id="ontario-input" name="ontario-input">
   <mock:shadow-root>
-    <div class="ontario-form-group">
+    <div>
       <label class="ontario-label" htmlfor="ontario-input">
         Ontario Input
         <span class="ontario-label__flag">

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -22,7 +22,7 @@ describe('ontario-input', () => {
 			expect(page.root).toEqualHtml(`
 				<ontario-input element-id="ontario-input" caption='{"captionText": "Ontario Input"}' name="ontario-input">
 					<mock:shadow-root>
-						<div class="ontario-form-group">
+						<div>
 							<label class="ontario-label" htmlfor="ontario-input">
 								Ontario Input
 								<span class="ontario-label__flag">

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
@@ -406,7 +406,7 @@ export class OntarioRadioButtons implements RadioButtons {
 	render() {
 		const error = !!this.errorMessage;
 		return (
-			<div class={`ontario-form-group ${error ? 'ontario-input--error' : ''}`}>
+			<div class={error ? 'ontario-input--error' : ''}>
 				<fieldset class="ontario-fieldset" aria-describedby={this.hintTextId}>
 					{this.captionState.getCaption(undefined, !!this.internalHintExpander)}
 					{this.internalHintText && (

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/test/ontario-radio-button.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/test/ontario-radio-button.spec.tsx
@@ -10,7 +10,7 @@ describe('ontario-radio-buttons', () => {
 		expect(page.root).toEqualHtml(`
       <ontario-radio-buttons>
         <mock:shadow-root>
-          <div class="ontario-form-group">
+          <div>
             <fieldset class="ontario-fieldset">
                 <legend class="ontario-fieldset__legend">
                   <span class="ontario-label__flag">

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
@@ -326,7 +326,7 @@ export class OntarioTextarea implements Input {
 	render() {
 		const error = !!this.errorMessage;
 		return (
-			<div class={`ontario-form-group ${error ? 'ontario-textarea--error' : ''}`}>
+			<div class={error ? 'ontario-textarea--error' : ''}>
 				{this.captionState.getCaption(this.getId(), !!this.internalHintExpander)}
 				{this.internalHintText && (
 					<ontario-hint-text

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/test/__snapshots__/ontario-textarea.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/test/__snapshots__/ontario-textarea.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ontario-textarea snapshot should render the expected html 1`] = `
 <ontario-textarea caption="{&quot;captionText&quot;: &quot;Ontario Textarea&quot;}" element-id="ontario-textarea" name="ontario-textarea">
   <mock:shadow-root>
-    <div class="ontario-form-group">
+    <div>
       <label class="ontario-label" htmlfor="ontario-textarea">
         Ontario Textarea
         <span class="ontario-label__flag">

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/test/ontario-textarea.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/test/ontario-textarea.spec.tsx
@@ -21,7 +21,7 @@ describe('ontario-textarea', () => {
 			expect(page.root).toEqualHtml(`
 				<ontario-textarea name="ontario-textarea" element-id="ontario-textarea" caption='{"captionText": "Ontario Textarea"}'>
 					<mock:shadow-root>
-						<div class="ontario-form-group">
+						<div>
 							<label htmlfor="ontario-textarea" class="ontario-label">
 								Ontario Textarea
 								<span class="ontario-label__flag">

--- a/packages/ontario-design-system-global-styles/src/styles/scss/5-layout/_form-group.layout.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/5-layout/_form-group.layout.scss
@@ -1,0 +1,7 @@
+@use '../1-variables/spacing.variables' as spacing;
+
+//for general forms
+@warn "The `ontario-form-group` class will be deprecated and replaced with a vertical spacing component in future.";
+.ontario-form-group:last-of-type {
+	margin-bottom: 2.5rem;
+}

--- a/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_form.component.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_form.component.scss
@@ -7,15 +7,6 @@
 @use '../1-variables/letter-spacing.variables' as letterSpacing;
 @use '../1-variables/line-heights.variables' as lineHeight;
 
-//for general forms
-.ontario-form-group:last-of-type {
-	margin-bottom: 2.5rem;
-}
-
-.ontario-form-group:last-of-type {
-	margin-bottom: spacing.$spacing-8;
-}
-
 .ontario-fieldset__legend {
 	color: colours.$ontario-colour-black;
 	font-family: typography.$ontario-font-raleway-modified;

--- a/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_text-inputs.component.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/6-components/_text-inputs.component.scss
@@ -56,8 +56,3 @@
 .ontario-input--20-char-width {
 	max-width: 41ex;
 }
-
-//for general forms
-.ontario-form-group:last-of-type {
-	margin-bottom: 2.5rem;
-}

--- a/packages/ontario-design-system-global-styles/src/styles/scss/theme.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/theme.scss
@@ -43,6 +43,7 @@
 
 /*** 5 - Layout ***/
 @forward './5-layout/grid.layout';
+@forward './5-layout/form-group.layout';
 
 /*** 6 - Components ***/
 @forward './6-components/buttons.component';


### PR DESCRIPTION
This task removes the `ontario-form-group` class from the following component markups:
- checkboxes
- date inputs
- text inputs
- textareas
- radio buttons
- dropdown lists

Tests and snapshots for the above components were also updated to reflect the changes.

The `ontario-form-group` styles associated with the class were removed from both the `text-input` and `form` component styles in the global styles package, and added back under the layout folder. A warning has been added to notify users that this class will eventually be replaced with a new vertical spacing component.