### PR TITLE
DS-2120: added white colour to the background of the card to avoid bleed

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
@@ -24,6 +24,7 @@
 	transition: all 0.3s ease-in-out;
 	position: relative;
 	cursor: pointer;
+	background: colours.$ontario-colour-white;
 
 	&:hover {
 		box-shadow: 0rem 0.375rem 0.75rem 0.125rem rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
Fixes: 
- DS-2120: Background colour "bleeds" through ontario-card web component 

