### PR TITLE
DS-2125: deduplicate SASS variable naming conflict

### DIFF
--- a/packages/ontario-design-system-complete-styles/gulpfile.js
+++ b/packages/ontario-design-system-complete-styles/gulpfile.js
@@ -41,16 +41,12 @@ const processSass = (opts) => {
 		sassOptions.sourceComments = true;
 	}
 
-	src('./src/styles/scss/theme.scss')
+	return src('./src/styles/scss/theme.scss')
 		.pipe(sass(sassOptions).on('error', sass.logError))
 		.pipe(autoprefixer())
 		.pipe(concat(gulpif(opts.compress, 'ontario-theme.min.css', 'ontario-theme.css')))
 		.pipe(gulpif(opts.compress, minify()))
 		.pipe(dest(`${distDir}/styles/css/compiled`));
-
-	if (opts.callback) {
-		opts.callback();
-	}
 };
 
 task('copy:ds-global-styles', () => {
@@ -98,17 +94,15 @@ task('generate:components-import-file', async (done) => {
 });
 
 task('sass:build', (done) => {
-	processSass({
+	return processSass({
 		compress: false,
 		debug: false,
-		callback: done,
 	});
 });
 
 task('sass:minify', (done) => {
-	processSass({
+	return processSass({
 		compress: true,
-		callback: done,
 	});
 });
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/test/ontario-footer.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/test/ontario-footer.spec.tsx
@@ -58,7 +58,7 @@ describe('ontario-footer', () => {
                   <li><a class="ontario-footer__link" href="https://www.ontario.ca/feedback/contact-us">Contact</a></li>
                 </ul>
                 <div class="ontario-footer__copyright">
-                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–24</span></a>
+                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–25</span></a>
                 </div>
               </div>
             </div>
@@ -201,7 +201,7 @@ describe('ontario-footer', () => {
                   <li><a class="ontario-footer__link" href="https://www.ontario.ca/feedback/contact-us">Contact</a></li>
                 </ul>
                 <div class="ontario-footer__copyright">
-                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–24</span></a>
+                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–25</span></a>
                 </div>
               </div>
             </div>
@@ -370,7 +370,7 @@ describe('ontario-footer', () => {
                   <li><a class="ontario-footer__link" href="https://www.ontario.ca/feedback/contact-us">Contact</a></li>
                 </ul>
                 <div class="ontario-footer__copyright">
-                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–24</span></a>
+                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–25</span></a>
                 </div>
               </div>
             </div>
@@ -549,7 +549,7 @@ describe('ontario-footer', () => {
                   <li><a class="ontario-footer__link" href="https://www.ontario.ca/feedback/contact-us">Contact</a></li>
                 </ul>
                 <div class="ontario-footer__copyright">
-                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–24</span></a>
+                  <a class="ontario-footer__link" href="https://www.ontario.ca/page/copyright-information">© King's Printer for Ontario, <span class="ontario-nbsp">2012–25</span></a>
                 </div>
               </div>
             </div>

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.scss
@@ -14,8 +14,8 @@
 @use '@ongov/ontario-design-system-global-styles/dist/styles/scss/6-components/_text-inputs.component.scss';
 @use '@ongov/ontario-design-system-global-styles/dist/styles/scss/7-overrides/_visibility.overrides.scss';
 
-$ontario-search-input-padding: 7.2rem;
-$ontario-search-input-padding--mobile: 6.4rem;
+$ontario-search-padding: 7.2rem;
+$ontario-search-padding--mobile: 6.4rem;
 
 $ontario-header-logo-width: 180px;
 $ontario-header-logo-width--mobile: 45px;
@@ -304,7 +304,7 @@ $ontario-navigation-container-min-width: 290px;
 	margin-bottom: spacing.$spacing-0;
 	height: globalVariables.$standard-input-height;
 	padding-left: spacing.$spacing-3;
-	padding-right: $ontario-search-input-padding;
+	padding-right: $ontario-search-padding;
 
 	&:invalid + input[type='reset'] {
 		display: none;
@@ -346,7 +346,7 @@ $ontario-navigation-container-min-width: 290px;
 
 	@media screen and (min-width: breakpoints.$small-breakpoint) and (max-width: breakpoints.$medium-breakpoint) {
 		padding-left: spacing.$spacing-4;
-		padding-right: $ontario-search-input-padding--mobile;
+		padding-right: $ontario-search-padding--mobile;
 	}
 }
 


### PR DESCRIPTION
This PR moves some variable renames from #6 to the `alpha` branch.

Also:

- Update gulpfile.js' SASS functions to use return values instead of callbacks.
- Update Footer test with 2025 copyright date. (This will be found in a few PRs until things settle)

JIRA: DS-2125

**Note**: This is targeting `alpha` so we can get the fix out for testing.