### PR TITLE
DS-2111: cards not full width

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
@@ -23,7 +23,7 @@
 }
 
 .ontario-card-collecton--cards-per-row-3 ::slotted(ontario-card) {
-	width: calc(33.3% - 1.25rem);
+	width: calc(33.3% - 1.33rem);
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
 		width: 100;

--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
@@ -5,7 +5,7 @@
 .ontario-card-collection__container {
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
+	gap: spacing.$spacing-6;
 	margin: spacing.$spacing-0;
 	padding: spacing.$spacing-0;
 }

--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
@@ -26,7 +26,7 @@
 	width: calc(33.3% - 1.33rem);
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
-		width: 100;
+		width: 100%;
 	}
 }
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.scss
@@ -5,51 +5,35 @@
 .ontario-card-collection__container {
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: flex-start;
+	justify-content: space-between;
 	margin: spacing.$spacing-0;
 	padding: spacing.$spacing-0;
 }
 
 .ontario-card-collecton--cards-per-row-4 ::slotted(ontario-card) {
-	width: calc(25% - 2rem);
-
-	&:nth-child(4n) {
-		margin-right: spacing.$spacing-0;
-	}
+	width: calc(25% - 1.5rem);
 
 	@media screen and (max-width: breakpoints.$medium-breakpoint) {
-		width: calc(50% - 1.25rem);
-
-		&:nth-child(2n) {
-			margin-right: spacing.$spacing-0;
-		}
+		width: calc(50% - 1rem);
 	}
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
-		width: calc(100% - 0.5rem);
+		width: 100%;
 	}
 }
 
 .ontario-card-collecton--cards-per-row-3 ::slotted(ontario-card) {
-	width: calc(33.3% - 1.75rem);
-
-	&:nth-child(3n) {
-		margin-right: spacing.$spacing-0;
-	}
+	width: calc(33.3% - 1.25rem);
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
-		width: calc(100% - 0.5rem);
+		width: 100;
 	}
 }
 
 .ontario-card-collecton--cards-per-row-2 ::slotted(ontario-card) {
-	width: calc(50% - 1.25rem);
-
-	&:nth-child(2n) {
-		margin-right: spacing.$spacing-0;
-	}
+	width: calc(50% - 1rem);
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
-		width: calc(100% - 0.5rem);
+		width: 100%;
 	}
 }

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
@@ -13,7 +13,7 @@
 .ontario-card {
 	box-shadow: 0rem 0.1875rem 0.5rem 0.0625rem rgba(0, 0, 0, 0.4);
 	border-radius: globalVariables.$global-radius;
-	margin: spacing.$spacing-0 spacing.$spacing-7 spacing.$spacing-7 spacing.$spacing-0;
+	margin-bottom: spacing.$spacing-7;
 	padding: spacing.$spacing-0;
 	/*
 	 * Required for cards to stay the same height regardless of content size.

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
@@ -190,7 +190,7 @@ $ontario-card-heading-colours: (
 
 .ontario-card__text-container {
 	.ontario-card__card-type--horizontal & {
-		width: 66.66%;
+		width: math.percentage(math.div(2, 3));
 	}
 
 	.ontario-card__image-size-one-fourth & {

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
@@ -108,7 +108,11 @@
 
 	.ontario-card--image-true & {
 		border-radius: 0;
-		@at-root .ontario-card__card-type--horizontal & {
+		@at-root .ontario-card__image-right & {
+			border-radius: globalVariables.$global-radius 0 0 0;
+		}
+
+		@at-root .ontario-card__image-left & {
 			border-radius: 0 globalVariables.$global-radius 0 0;
 		}
 	}
@@ -186,7 +190,7 @@ $ontario-card-heading-colours: (
 
 .ontario-card__text-container {
 	.ontario-card__card-type--horizontal & {
-		width: 66.6%;
+		width: 66.66%;
 	}
 
 	.ontario-card__image-size-one-fourth & {

--- a/packages/ontario-design-system-component-library/src/index.html
+++ b/packages/ontario-design-system-component-library/src/index.html
@@ -415,7 +415,7 @@
 							</ontario-card-collection>
 
 							<h3>Edge cases</h3>
-							<ontario-card-collection cards-per-row="4">
+							<ontario-card-collection cards-per-row="3">
 								<ontario-card
 									header-colour="orange"
 									label="Card Title 1 Card Title 1 Card Title 1"
@@ -437,7 +437,7 @@
 								</ontario-card>
 							</ontario-card-collection>
 
-							<ontario-card-collection cards-per-row="4">
+							<ontario-card-collection cards-per-row="2">
 								<ontario-card
 									layout="horizontal"
 									header-colour="orange"


### PR DESCRIPTION
Fix for DS-2111: Update widths of ontario-card-collection rows to account for gap between cards. This allows the cards to span the full width of the ontario-row. 