### PR TITLE
DS-2174: add index.js file to allow for import in JS

### DIFF
--- a/packages/ontario-design-system-global-styles/gulpfile.js
+++ b/packages/ontario-design-system-global-styles/gulpfile.js
@@ -80,13 +80,15 @@ task('sass:copy-tokens', () => {
 
 task('sass:build-minify', parallel('sass:build', 'sass:minify'));
 
+task('index:move', () => fs.cp(paths.index, paths.output.index));
+
 // Move all non-style related fonts to the dist/fonts folder
-task('fonts-move', () => {
+task('fonts:move', () => {
 	return fs.cp(paths.fonts, paths.output.fontsDist, { recursive: true });
 });
 
 // Move all favicons to the dist/favicons folder
-task('favicons-move', () => {
+task('favicons:move', () => {
 	return fs.cp(paths.favicons, paths.output.favicons, { recursive: true });
 });
 
@@ -101,7 +103,15 @@ task('clean', async () => {
 
 task(
 	'deploy',
-	series('clean', 'fonts-move', 'favicons-move', 'sass:copy-dist', 'sass:copy-tokens', 'sass:build-minify'),
+	series(
+		'clean',
+		'index:move',
+		'fonts:move',
+		'favicons:move',
+		'sass:copy-dist',
+		'sass:copy-tokens',
+		'sass:build-minify',
+	),
 );
 
 task('default', series('watch'));

--- a/packages/ontario-design-system-global-styles/package.json
+++ b/packages/ontario-design-system-global-styles/package.json
@@ -5,6 +5,7 @@
 	"description": "Includes the Ontario Design System global styles that are used for more generic elements and layouts, as well as fonts and favicon files.",
 	"license": "Apache-2.0",
 	"type": "module",
+	"main": "dist/index.js",
 	"style": "dist/styles/css/compiled/ontario-theme.min.css",
 	"files": [
 		"dist/",

--- a/packages/ontario-design-system-global-styles/paths-constants.js
+++ b/packages/ontario-design-system-global-styles/paths-constants.js
@@ -10,6 +10,7 @@ const paths = {
 	},
 	fonts: './src/fonts',
 	favicons: './src/favicons',
+	index: './src/index.js',
 	dsTokens: {
 		src: '../ontario-design-system-design-tokens/dist/scss/_variables.scss',
 		dest: './dist/styles/scss/1-variables/_tokens.variables.scss',
@@ -20,6 +21,7 @@ const paths = {
 		fontsDist: './dist/fonts/',
 		styles: './dist/styles/',
 		favicons: './dist/favicons',
+		index: './dist/index.js',
 	},
 };
 

--- a/packages/ontario-design-system-global-styles/src/index.js
+++ b/packages/ontario-design-system-global-styles/src/index.js
@@ -1,0 +1,1 @@
+import './styles/scss/theme.scss';


### PR DESCRIPTION
- Rename gulp tasks to follow a consistent naming convention.
- Update `paths-constants.js` with paths for `index.js` file.
- Update `package.json` to include a `main` entry pointing to new `index.js` file.