### PR TITLE
DS-2172: Fixes broken links + styles in header + footer components for React projects

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
@@ -1,16 +1,4 @@
-import {
-	Component,
-	State,
-	Element,
-	h,
-	Prop,
-	Event,
-	Listen,
-	Watch,
-	getAssetPath,
-	EventEmitter,
-	AttachInternals,
-} from '@stencil/core';
+import { Component, State, Element, h, Prop, Event, Listen, Watch, EventEmitter, AttachInternals } from '@stencil/core';
 import { v4 as uuid } from 'uuid';
 
 import { DropdownOption } from './dropdown-option.interface';
@@ -27,6 +15,7 @@ import {
 } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 import { hasMultipleTrueValues } from '../../utils/helper/utils';
+import { getImageAssetSrcPath } from '../../utils/helper/assets';
 import { Language } from '../../utils/common/language-types';
 import { constructHintTextObject } from '../../utils/components/hints/hints';
 import { InputFocusBlurEvent, EventType, InputInteractionEvent } from '../../utils/events/event-handler.interface';
@@ -442,7 +431,7 @@ export class OntarioDropdownList implements Dropdown {
 
 	private getDropdownArrow() {
 		return {
-			backgroundImage: `url(${getAssetPath('./assets/ontario-material-dropdown-arrow-48px.svg')})`,
+			backgroundImage: `url(${getImageAssetSrcPath('ontario-material-dropdown-arrow-48px.svg')})`,
 		};
 	}
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, State, Watch, Listen, getAssetPath } from '@stencil/core';
+import { Component, Prop, h, State, Watch, Listen } from '@stencil/core';
 
 import {
 	FooterLinks,
@@ -8,11 +8,13 @@ import {
 	SimpleFooterLinks,
 } from './ontario-footer-interface';
 import { ExpandedFooterWrapper, FooterColumn, FooterSocialLinksProps, SimpleFooter } from './components';
+
 import { isInvalidTwoColumnOptions, isInvalidThreeColumnOptions } from './utils';
 import { Language } from '../../utils/common/language-types';
 import { validateLanguage } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 import { ConsoleType } from '../../utils/console-message/console-message.enum';
+import { getImageAssetSrcPath } from '../../utils/helper/assets';
 
 import translations from '../../translations/global.i18n.json';
 
@@ -178,15 +180,6 @@ export class OntarioFooter {
 	}
 
 	/**
-	 * Generate a link to the given image based on the base asset path.
-	 * @param imageName Name of the image to build the path to
-	 * @returns Path to image with asset path
-	 */
-	private getImageAssetSrcPath(imageName: string): string {
-		return `${this.assetBasePath ? this.assetBasePath : getAssetPath('./assets')}/${imageName}`;
-	}
-
-	/**
 	 * Generate CSS url to the background image
 	 * @returns path to the background image
 	 */
@@ -195,7 +188,7 @@ export class OntarioFooter {
 			? 'footer-expanded-supergraphic-logo.svg'
 			: 'footer-default-supergraphic-logo.svg';
 
-		return `url(${this.getImageAssetSrcPath(supergraphicLogoFile)})`;
+		return `url(${getImageAssetSrcPath(supergraphicLogoFile, this.assetBasePath)})`;
 	}
 
 	private getFooterClasses() {

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, Watch, h, Listen, Element, getAssetPath } from '@stencil/core';
+import { Component, Prop, State, Watch, h, Listen, Element } from '@stencil/core';
 
 import { Input } from '../../utils/common/input/input';
 import {
@@ -16,6 +16,7 @@ import OntarioIconSearchWhite from '../ontario-icon/assets/ontario-icon-search-w
 import OntarioHeaderDefaultData from './ontario-header-default-data.json';
 
 import { Language } from '../../utils/common/language-types';
+import { getImageAssetSrcPath } from '../../utils/helper/assets';
 import { validateLanguage } from '../../utils/validation/validation-functions';
 
 import translations from '../../translations/global.i18n.json';
@@ -23,11 +24,7 @@ import config from '../../config.json';
 
 @Component({
 	tag: 'ontario-header',
-	styleUrls: {
-		ontario: 'ontario-header.scss',
-		application: 'ontario-application-header.scss',
-		serviceOntario: 'service-ontario-header.scss',
-	},
+	styleUrls: ['ontario-header.scss', 'ontario-application-header.scss', 'service-ontario-header.scss'],
 	shadow: true,
 	assetsDirs: ['./assets'],
 })
@@ -340,12 +337,19 @@ export class OntarioHeader {
 	}
 
 	/**
-	 * Generate a link to the given image based on the base asset path.
-	 * @param imageName Name of the image to build the path to
-	 * @returns Path to image with asset path
+	 * Generate the full path to an image asset based on the base asset path.
+	 *
+	 * - If `assetBasePath` is provided, it is used as the base path.
+	 * - If not, attempts to use Stencil's `getAssetPath` (for Stencil/Angular builds).
+	 * - If that fails (e.g., in React), falls back to `/assets/`, assuming assets are in the public folder.
+	 *
+	 * This allows the component to work across multiple environments (Stencil, Angular, React).
+	 *
+	 * @param imageName - The name of the image file.
+	 * @returns The full image path as a string.
 	 */
 	private getImageAssetSrcPath(imageName: string): string {
-		return `${this.assetBasePath ? this.assetBasePath : getAssetPath('./assets')}/${imageName}`;
+		return getImageAssetSrcPath(imageName, this.assetBasePath);
 	}
 
 	/**

--- a/packages/ontario-design-system-component-library/src/utils/helper/assets.ts
+++ b/packages/ontario-design-system-component-library/src/utils/helper/assets.ts
@@ -18,7 +18,8 @@ export function getImageAssetSrcPath(imageName: string, assetBasePath?: string):
 
 	try {
 		return getAssetPath(`./assets/${imageName}`);
-	} catch {
+	} catch (error) {
+		console.warn(`getAssetPath failed for ${imageName}, falling back to /assets/:`, error);
 		return `/assets/${imageName}`;
 	}
 }

--- a/packages/ontario-design-system-component-library/src/utils/helper/assets.ts
+++ b/packages/ontario-design-system-component-library/src/utils/helper/assets.ts
@@ -1,0 +1,24 @@
+import { getAssetPath } from '@stencil/core';
+
+/**
+ * Generate the full path to an image asset based on the base asset path.
+ *
+ * - If `assetBasePath` is provided, it is used as the base path.
+ * - If not, attempts to use Stencil's `getAssetPath` (for Stencil/Angular builds).
+ * - If that fails (e.g., in React), falls back to `/assets/`, assuming assets are in the public folder.
+ *
+ * @param imageName - The name of the image file.
+ * @param assetBasePath - Optional base path for assets.
+ * @returns The full image path as a string.
+ */
+export function getImageAssetSrcPath(imageName: string, assetBasePath?: string): string {
+	if (assetBasePath) {
+		return `${assetBasePath.replace(/\/$/, '')}/${imageName}`;
+	}
+
+	try {
+		return getAssetPath(`./assets/${imageName}`);
+	} catch {
+		return `/assets/${imageName}`;
+	}
+}


### PR DESCRIPTION
This merge request introduces a refactor to standardize the way asset paths are resolved across the `ontario-design-system` components. A shared utility function, `getImageAssetSrcPath`, has been created and integrated into the `ontario-header`, `ontario-footer`, and `ontario-dropdown-list` components. This ensures consistency, maintainability, and reusability of asset path resolution logic.

### **Changes Made**
**Shared Utility Function**
- Created a new utility function getImageAssetSrcPath in `src/utils/helper/assets.ts.` The function resolves asset paths dynamically based on the assetBasePath prop or falls back to default paths.

**Component Updates**
`ontario-header`:
- Replaced inline asset path resolution logic with the shared getImageAssetSrcPath utility.
- Updated styleURL links - the modes were not being set correctly and breaking the React PoC project

`ontario-footer`:
- Updated the background image path resolution to use `getImageAssetSrcPath`.

`ontario-dropdown-list`:
- Updated the dropdown arrow image path resolution to use `getImageAssetSrcPath`.

