### PR TITLE
DS-2190: focus now always follows the index, regardless of whether you us…

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
@@ -173,6 +173,15 @@ export class OntarioHeaderApplicationMenu {
 		this.parseMenuItems();
 	}
 
+	componentDidLoad() {
+		const focusableElements = this.menu.querySelectorAll('.ontario-menu-item');
+		focusableElements.forEach((element, index) => {
+			element.addEventListener('focus', () => {
+				this.currentIndex = index;
+			});
+		});
+	}
+
 	/**
 	 * Assigning values to elements to use them as ref
 	 */

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
@@ -99,8 +99,7 @@ export class OntarioHeaderApplicationMenu {
 	@Listen('keydown', { target: 'window' })
 	handleKeyDown(event: KeyboardEvent) {
 		if (this.menuIsOpen) {
-			const focusableElements = this.menu.querySelectorAll('.ontario-menu-item');
-			const focusableArray = Array.prototype.slice.call(focusableElements);
+			const focusableElements: NodeListOf<HTMLElement> = this.menu.querySelectorAll('.ontario-menu-item');
 
 			switch (event.key) {
 				case 'ArrowDown':
@@ -108,20 +107,35 @@ export class OntarioHeaderApplicationMenu {
 					if (this.currentIndex === -1 || this.currentIndex === undefined) {
 						this.currentIndex = 0;
 					} else {
-						this.currentIndex = (this.currentIndex + 1) % focusableArray.length;
+						this.currentIndex = (this.currentIndex + 1) % focusableElements.length;
 					}
-					(focusableArray[this.currentIndex] as HTMLElement).focus();
+					focusableElements[this.currentIndex].focus();
+					/**
+					 * Tried other ways of triggering this function to condense code via a watch on currentIndex,
+					 * and also tried sticking at the bottom of the switch's parent if statement.
+					 *
+					 * Both attempts led to inconsistent results (e.g. the aria message was out of sync with currentIndex)
+					 * or just didn't appear at all. Setting this at the source seems to have the best outcome.
+					 */
 					this.updateAriaLive(this.currentIndex);
 					break;
 				case 'ArrowUp':
 					event.preventDefault();
 					if (this.currentIndex === -1 || this.currentIndex === undefined) {
-						this.currentIndex = focusableArray.length - 1;
+						this.currentIndex = focusableElements.length - 1;
 					} else {
-						this.currentIndex = (this.currentIndex - 1 + focusableArray.length) % focusableArray.length;
+						this.currentIndex = (this.currentIndex - 1 + focusableElements.length) % focusableElements.length;
 					}
-					(focusableArray[this.currentIndex] as HTMLElement).focus();
+					focusableElements[this.currentIndex].focus();
 					this.updateAriaLive(this.currentIndex);
+					break;
+				case 'Tab':
+					focusableElements.forEach((element, index) => {
+						element.addEventListener('focus', () => {
+							this.currentIndex = index;
+							this.updateAriaLive(this.currentIndex);
+						});
+					});
 					break;
 			}
 		}
@@ -171,15 +185,6 @@ export class OntarioHeaderApplicationMenu {
 
 	componentWillLoad() {
 		this.parseMenuItems();
-	}
-
-	componentDidLoad() {
-		const focusableElements = this.menu.querySelectorAll('.ontario-menu-item');
-		focusableElements.forEach((element, index) => {
-			element.addEventListener('focus', () => {
-				this.currentIndex = index;
-			});
-		});
 	}
 
 	/**

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
@@ -234,6 +234,7 @@ export class OntarioHeader {
 		if (this.menuToggled && event.key === 'Escape') {
 			this.menuToggled = false;
 			this.menuButtonToggled.emit(this.menuToggled);
+			this.returnFocusToMenuButton();
 		}
 	}
 
@@ -374,6 +375,22 @@ export class OntarioHeader {
 			}
 		}
 		return;
+	}
+
+	/**
+	 * Returns focus to the menu button when the menu is closed.
+	 *
+	 * The `setTimeout` is used to ensure that the focus logic executes after the DOM updates
+	 * caused by closing the menu. Without the timeout, the focus might not work as expected
+	 * because the DOM changes (e.g., removing focusable elements) might not have completed yet.
+	 */
+	private returnFocusToMenuButton() {
+		const menuToggleButton = this.el.shadowRoot?.querySelector('.ontario-header__menu-toggler') as HTMLElement;
+		if (menuToggleButton) {
+			setTimeout(() => {
+				menuToggleButton.focus();
+			}, 0);
+		}
 	}
 
 	/**

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
@@ -234,7 +234,7 @@ export class OntarioHeader {
 		if (this.menuToggled && event.key === 'Escape') {
 			this.menuToggled = false;
 			this.menuButtonToggled.emit(this.menuToggled);
-			this.returnFocusToMenuButton();
+			this.focusMenuButton();
 		}
 	}
 
@@ -378,22 +378,6 @@ export class OntarioHeader {
 	}
 
 	/**
-	 * Returns focus to the menu button when the menu is closed.
-	 *
-	 * The `setTimeout` is used to ensure that the focus logic executes after the DOM updates
-	 * caused by closing the menu. Without the timeout, the focus might not work as expected
-	 * because the DOM changes (e.g., removing focusable elements) might not have completed yet.
-	 */
-	private returnFocusToMenuButton() {
-		const menuToggleButton = this.el.shadowRoot?.querySelector('.ontario-header__menu-toggler') as HTMLElement;
-		if (menuToggleButton) {
-			setTimeout(() => {
-				menuToggleButton.focus();
-			}, 0);
-		}
-	}
-
-	/**
 	 * Generate a link to the given image based on the base asset path.
 	 * @param imageName Name of the image to build the path to
 	 * @returns Path to image with asset path
@@ -513,16 +497,14 @@ export class OntarioHeader {
 	}
 
 	/**
-	 * Handles the focus when menu/toggle button is clicked.
+	 * Handles the search focus when the search toggle button is clicked.
 	 * When search button is clicked, the search bar is in focus,
 	 * when the closed button is clicked, the search button is back into focus.
-	 * When the menu is closed, the menu button should be out of focus.
 	 */
 	componentDidUpdate() {
 		if (this.type == 'ontario') {
 			if (this.searchToggle === true) this.searchBar.focus();
 			if (this.searchToggle === false) this.searchButton.focus();
-			if (this.menuToggled === false) this.menuButton.blur();
 		}
 	}
 


### PR DESCRIPTION
The fix ensures that the currentIndex is always in sync with the currently focused menu item, regardless of whether the focus change is triggered by the Tab key, arrow keys, or any other method.