### PR TITLE
ci(renovate): remove pnpm version from Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install PNPM
         uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 10.11.0
 
       - name: Run Renovate
         uses: renovatebot/github-action@v42.0.0


### PR DESCRIPTION
This PR updates the `renovate.yml` file and removed the `version` property on the `pnpm/action-setup` action.  This will allow the workflow to use the version of pnpm specified in the `package.json` file, as outlined [in the documentation](https://github.com/pnpm/action-setup/tree/v4.0.0/#version).