### PR TITLE
Install pnpm in documentation workflow

### DIFF
--- a/.github/workflows/app-docs.yml
+++ b/.github/workflows/app-docs.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use Node.js ${{ inputs.node-version }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
During the monorepo upgrades, `pnpm` installation was missed in the documentation workflow.  This prevents the deployment step from successfully executing. This PR adds it in.

_Note_: We might not need the _Install pnpm_ and _Use Node.js_ steps, but that's outside the scope of this PR.