### PR TITLE
DS-2280: Create test page for ontario-aside

### DIFF
--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -7,7 +7,7 @@ export default function OntarioAsidePage() {
 			<Grid>
 				<h1>ontario-aside</h1>
 
-				<h2>"HeadingType" Prop variant</h2>
+				<h2>"heading-type" Prop Variants</h2>
 
 				<h3>h3 HeadingType</h3>
 				<OntarioAside

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -9,7 +9,7 @@ export default function OntarioAsidePage() {
 
 				<h2>"heading-type" Prop Variants</h2>
 
-				<h3>h2 Heading Type</h3>
+				<h3>H2</h3>
 				<OntarioAside
 					headingType="h2"
 					headingContentType="string"
@@ -18,7 +18,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>h3 Heading Type</h3>
+				<h3>H3</h3>
 				<OntarioAside
 					headingType="h3"
 					headingContentType="string"
@@ -27,7 +27,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>h4 Heading Type</h3>
+				<h3>H4</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -36,7 +36,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>h5 Heading Type</h3>
+				<h3>H5</h3>
 				<OntarioAside
 					headingType="h5"
 					headingContentType="string"
@@ -45,7 +45,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>h6 Heading Type</h3>
+				<h3>H6</h3>
 				<OntarioAside
 					headingType="h6"
 					headingContentType="string"
@@ -56,7 +56,7 @@ export default function OntarioAsidePage() {
 
 				<h2>"hightlight-colour" Prop Variants</h2>
 
-				<h3>highlight colour - teal</h3>
+				<h3>Teal</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -65,7 +65,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - gold</h3>
+				<h3>Gold</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -74,7 +74,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - yellow</h3>
+				<h3>Yellow</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -83,7 +83,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - taupe</h3>
+				<h3>Taupe</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -92,7 +92,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - green</h3>
+				<h3>Green</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -101,7 +101,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - lime</h3>
+				<h3>Lime</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -110,7 +110,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - sky</h3>
+				<h3>Sky</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -119,7 +119,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - blue</h3>
+				<h3>Blue</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -128,7 +128,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h3>highlight colour - purple</h3>
+				<h3>Purple</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -139,7 +139,7 @@ export default function OntarioAsidePage() {
 
 				<h2>"heading-content-type" Prop Variants</h2>
 
-				<h3>heading content type - string</h3>
+				<h3>String</h3>
 				<OntarioAside
 					headingType="h2"
 					headingContentType="string"
@@ -148,13 +148,23 @@ export default function OntarioAsidePage() {
 					content="Updated content"
 				></OntarioAside>
 
-				<h3>heading content type - html</h3>
+				<h3>HTML</h3>
 				<OntarioAside
 					headingType="h2"
 					headingContentType="html"
-					headingContent="Did you know?"
+					headingContent={
+						<div className="ontario-aside">
+							<p>
+								Did you know? <strong>HTML</strong> in heading!
+							</p>
+						</div>
+					}
 					highlightColour="teal"
-					content="<div>Updated content with <strong>HTML</strong> support.</div>"
+					content={
+						<div>
+							Updated content with <strong>HTML</strong> support.
+						</div>
+					}
 				></OntarioAside>
 			</Grid>
 		</main>

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -153,11 +153,9 @@ export default function OntarioAsidePage() {
 					headingType="h2"
 					headingContentType="html"
 					headingContent={
-						<div className="ontario-aside">
-							<p>
-								Did you know? <strong>HTML</strong> in heading!
-							</p>
-						</div>
+						<p>
+							Did you know? <strong>HTML</strong> in heading!
+						</p>
 					}
 					highlightColour="teal"
 					content={

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -9,6 +9,15 @@ export default function OntarioAsidePage() {
 
 				<h2>"heading-type" Prop Variants</h2>
 
+				<h3>h2 Heading Type</h3>
+				<OntarioAside
+					headingType="h2"
+					headingContentType="string"
+					headingContent="Quick fact:"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
 				<h3>h3 Heading Type</h3>
 				<OntarioAside
 					headingType="h3"
@@ -18,9 +27,36 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
+				<h3>h4 Heading Type</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Quick fact:"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>h5 Heading Type</h3>
+				<OntarioAside
+					headingType="h5"
+					headingContentType="string"
+					headingContent="Quick fact:"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>h6 Heading Type</h3>
+				<OntarioAside
+					headingType="h6"
+					headingContentType="string"
+					headingContent="Quick fact:"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
 				<h2>"Hightlight-colour" Prop variant</h2>
 
-				<h3>h3 HeadingType</h3>
+				<h3>highlight colour - teal</h3>
 				<OntarioAside
 					headingType="h4"
 					headingContentType="string"
@@ -29,15 +65,96 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h2>"Content" Prop variant</h2>
+				<h3>highlight colour - gold</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
 
-				<h3>h3 HeadingType</h3>
+				<h3>highlight colour - yellow</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="yellow"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - taupe</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="taupe"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - green</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="green"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - lime</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="lime"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - sky</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="sky"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - blue</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="blue"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h3>highlight colour - purple</h3>
+				<OntarioAside
+					headingType="h4"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="purple"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h2>"heading-content-type" Prop variant</h2>
+
+				<h3>heading content type - string</h3>
 				<OntarioAside
 					headingType="h2"
 					headingContentType="string"
 					headingContent="Did you know?"
 					highlightColour="teal"
 					content="Updated content"
+				></OntarioAside>
+
+				<h3>heading content type - html</h3>
+				<OntarioAside
+					headingType="h2"
+					headingContentType="html"
+					headingContent="Did you know?"
+					highlightColour="teal"
+					content="<div>Updated content with <strong>HTML</strong> support.</div>"
 				></OntarioAside>
 			</Grid>
 		</main>

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -54,7 +54,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h2>"Hightlight-colour" Prop variant</h2>
+				<h2>"hightlight-colour" Prop Variants</h2>
 
 				<h3>highlight colour - teal</h3>
 				<OntarioAside
@@ -137,7 +137,7 @@ export default function OntarioAsidePage() {
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
 				></OntarioAside>
 
-				<h2>"heading-content-type" Prop variant</h2>
+				<h2>"heading-content-type" Prop Variants</h2>
 
 				<h3>heading content type - string</h3>
 				<OntarioAside

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -9,7 +9,7 @@ export default function OntarioAsidePage() {
 
 				<h2>"heading-type" Prop Variants</h2>
 
-				<h3>h3 HeadingType</h3>
+				<h3>h3 Heading Type</h3>
 				<OntarioAside
 					headingType="h3"
 					headingContentType="string"

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -22,11 +22,22 @@ export default function OntarioAsidePage() {
 
 				<h3>h3 HeadingType</h3>
 				<OntarioAside
-					headingType="h3"
+					headingType="h4"
 					headingContentType="string"
 					headingContent="Did you know?"
 					highlightColour="teal"
 					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h2>"Content" Prop variant</h2>
+
+				<h3>h3 HeadingType</h3>
+				<OntarioAside
+					headingType="h2"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="teal"
+					content="Updated content"
 				></OntarioAside>
 			</Grid>
 		</main>

--- a/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-aside/page.tsx
@@ -1,0 +1,34 @@
+import { Grid } from '../../grid';
+import { OntarioAside } from '@ongov/ontario-design-system-component-library-react';
+
+export default function OntarioAsidePage() {
+	return (
+		<main>
+			<Grid>
+				<h1>ontario-aside</h1>
+
+				<h2>"HeadingType" Prop variant</h2>
+
+				<h3>h3 HeadingType</h3>
+				<OntarioAside
+					headingType="h3"
+					headingContentType="string"
+					headingContent="Quick fact:"
+					highlightColour="gold"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+
+				<h2>"Hightlight-colour" Prop variant</h2>
+
+				<h3>h3 HeadingType</h3>
+				<OntarioAside
+					headingType="h3"
+					headingContentType="string"
+					headingContent="Did you know?"
+					highlightColour="teal"
+					content="As of 2013, Canada is responsible for 1.6% of global emissions, with Ontario responsible for less than 0.4% of global emissions."
+				></OntarioAside>
+			</Grid>
+		</main>
+	);
+}

--- a/packages/app-nextjs/src/app/page.tsx
+++ b/packages/app-nextjs/src/app/page.tsx
@@ -21,6 +21,9 @@ export default function Home() {
 						<li>
 							<Link href="/components/ontario-accordion">ontario-accordion</Link>
 						</li>
+						<li>
+							<Link href="/components/ontario-aside">ontario-aside</Link>
+						</li>
 					</ul>
 				</div>
 			</Grid>


### PR DESCRIPTION
This MR adds an ontario-aside test page to the Next PoC. It includes variants for content, highlight-colour, and heading-type. 