### PR TITLE
DS-2295: Create ontario-hint-text test page

### DIFF
--- a/packages/app-nextjs/src/app/components/ontario-hint-text/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-hint-text/page.tsx
@@ -1,0 +1,28 @@
+import { Grid } from '../../grid';
+import { OntarioHintText } from '@ongov/ontario-design-system-component-library-react';
+
+export default function OntarioButtonPage() {
+	return (
+		<main>
+			<Grid>
+				<h1>ontario-hint-text</h1>
+
+				<div>
+					<h2>"hint-content-type" Prop Variants</h2>
+
+					<h3>String</h3>
+					<OntarioHintText
+						hintContentType="string"
+						hint="This is example hint text content - string version."
+					></OntarioHintText>
+
+					<h3>HTML</h3>
+					<OntarioHintText
+						hintContentType="html"
+						hint="<p>This is an example of a multi-line hint text content - HTML version.</p><p>It can include <strong>HTML</strong> elements.</p>"
+					></OntarioHintText>
+				</div>
+			</Grid>
+		</main>
+	);
+}

--- a/packages/app-nextjs/src/app/page.tsx
+++ b/packages/app-nextjs/src/app/page.tsx
@@ -21,6 +21,9 @@ export default function Home() {
 						<li>
 							<Link href="/components/ontario-accordion">ontario-accordion</Link>
 						</li>
+						<li>
+							<Link href="/components/ontario-hint-text">ontario-hint-text</Link>
+						</li>
 					</ul>
 				</div>
 			</Grid>


### PR DESCRIPTION
This MR adds an `ontario-hint-text` test page to the Next PoC. It includes variants for hint-content-type(string or html).