### PR TITLE
DS-2294: Create ontario-hint-expander test page

### DIFF
--- a/packages/app-nextjs/src/app/components/ontario-hint-expander/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-hint-expander/page.tsx
@@ -1,0 +1,40 @@
+import { Grid } from '../../grid';
+import { OntarioHintExpander } from '@ongov/ontario-design-system-component-library-react';
+
+export default function OntarioHintExpanderPage() {
+	return (
+		<main>
+			<Grid>
+				<h1>ontario-hint-expander</h1>
+
+				<div>
+					<h2>"hint-content-type" Prop Variants</h2>
+
+					<h3>String</h3>
+					<OntarioHintExpander
+						hintContentType="string"
+						hint="What does temporary care mean?"
+						content="Temporary care means you are temporarily taking care of a child and you are not the child's birth or adoptive parent."
+					></OntarioHintExpander>
+
+					<h3>HTML</h3>
+					<OntarioHintExpander
+						hintContentType="html"
+						hint="What are some examples of legal issues?"
+						content="<div>
+                            <p>Legal issues may include:</p>
+                            <ul>
+                                <li>Criminal matters</li>
+                                <li>Family law issues like divorce, child custody or support</li>
+                                <li>Immigration and refugee matters</li>
+                                <li>Civil claims, including ones made in small claims court</li>
+                                <li>Issues before a tribunal or board, including landlord/tenant issues</li>
+                                <li>Social assistance review</li>
+                            </ul>
+                        </div>"
+					></OntarioHintExpander>
+				</div>
+			</Grid>
+		</main>
+	);
+}

--- a/packages/app-nextjs/src/app/page.tsx
+++ b/packages/app-nextjs/src/app/page.tsx
@@ -21,6 +21,9 @@ export default function Home() {
 						<li>
 							<Link href="/components/ontario-accordion">ontario-accordion</Link>
 						</li>
+						<li>
+							<Link href="/components/ontario-hint-expander">ontario-hint-expander</Link>
+						</li>
 					</ul>
 				</div>
 			</Grid>


### PR DESCRIPTION
This MR adds an `ontario-hint-expander` test page to the Next PoC. It includes variants for hint-content-type(string or html).