### PR TITLE
Remove unused header type swap code

### DIFF
--- a/packages/ontario-design-system-component-library/src/global.ts
+++ b/packages/ontario-design-system-component-library/src/global.ts
@@ -1,7 +1,1 @@
-import { setMode } from '@stencil/core';
-
-setMode((elm) => {
-	// NOTE: you can write whatever you want here - it's up to you. This
-	// function must return one of the style "modes" defined in step 1.
-	return (elm as any).type;
-});
+/* Place your global variable definitons here */


### PR DESCRIPTION
fix(web-components-library): remove unused header type swap code from global.ts file

 - this unused code is causing the `index.html` page load to fail