### PR TITLE
DS-2238: Fix hint-expander styles on checkbox + radio button components

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
@@ -37,6 +37,14 @@ $ontario-checkbox-box-shadow-outline: globalFunctions.px-to-rem(4);
 		margin: 0;
 	}
 
+	.ontario-checkboxes__hint-expander {
+		margin: spacing.$spacing-3 0 0 spacing.$spacing-3;
+
+		@media screen and (max-width: breakpoints.$small-breakpoint) {
+			margin-top: spacing.$spacing-4;
+		}
+	}
+
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
 		padding: 0 0 0 spacing.$spacing-7;
 		min-height: $ontario-checkboxes-size-mobile;
@@ -136,7 +144,7 @@ $ontario-checkbox-box-shadow-outline: globalFunctions.px-to-rem(4);
 }
 
 .ontario-checkboxes__hint-expander {
-	margin: spacing.$spacing-3 0 0 spacing.$spacing-2;
+	margin: spacing.$spacing-3 0 0 0;
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
 		margin-top: spacing.$spacing-4;

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.scss
@@ -29,6 +29,14 @@ $ontario-input-offset: math.div((globalVariables.$touch-target-size - $ontario-r
 	&:last-of-type {
 		margin-bottom: spacing.$spacing-0;
 	}
+
+	.ontario-radios__hint-expander {
+		margin: spacing.$spacing-3 spacing.$spacing-0 spacing.$spacing-0 spacing.$spacing-2;
+
+		@media screen and (max-width: breakpoints.$small-breakpoint) {
+			margin-top: spacing.$spacing-4;
+		}
+	}
 }
 
 .ontario-radios__input {
@@ -119,7 +127,7 @@ $ontario-input-offset: math.div((globalVariables.$touch-target-size - $ontario-r
 }
 
 .ontario-radios__hint-expander {
-	margin: spacing.$spacing-3 spacing.$spacing-0 spacing.$spacing-0 spacing.$spacing-2;
+	margin: spacing.$spacing-3 spacing.$spacing-0 spacing.$spacing-0 spacing.$spacing-0;
 
 	@media screen and (max-width: breakpoints.$small-breakpoint) {
 		margin-top: spacing.$spacing-4;


### PR DESCRIPTION
This MR updates the hint expander components on both the `ontario-checkboxes` and `ontario-radio-buttons` components. It updates the left-margin value for hint-expanders that fall under checkbox + radio button items (i.e individual options), as well as the left-margin for hint-expanders that fall under the whole checkbox/radio button question. 