### PR TITLE
DS-2233: Fix broken `isOpen` prop on ontario-accordion component

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/accordion.interface.ts
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/accordion.interface.ts
@@ -30,6 +30,12 @@ export interface Accordion extends Base {
 	ariaLabelText: string;
 }
 
+export enum AccordionChangeDetailReasons {
+	Init = 'init',
+	ToggleOne = 'toggle-one',
+	ToggleAll = 'toggle-all',
+}
+
 /**
  * The event detail payload emitted by the accordion component.
  */
@@ -44,5 +50,5 @@ export interface AccordionChangeDetail {
 	isBulk?: boolean;
 
 	/** Optional description of what triggered the event */
-	reason?: 'init' | 'toggle-one' | 'toggle-all';
+	reason?: AccordionChangeDetailReasons;
 }

--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/ontario-accordion.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/ontario-accordion.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, Element, Event, EventEmitter, State, h, Listen, Watch } from '@stencil/core';
+import { v4 as uuid } from 'uuid';
 
-import { Accordion, AccordionChangeDetail } from './accordion.interface';
+import { Accordion, AccordionChangeDetail, AccordionChangeDetailReasons } from './accordion.interface';
 import { ExpandCollapseButtonDetails } from './expandCollapseButtonDetails.interface';
 
 import { Language } from '../../utils/common/language-types';
@@ -99,7 +100,7 @@ export class OntarioAccordion {
 	@State() private openAccordionIndexes: number[] = [];
 
 	/** Unique prefix for a11y ids */
-	@State() private uidPrefix: string = `ontario-accordion-${Math.random().toString(36).slice(2, 9)}`;
+	@State() private uidPrefix: string = `ontario-accordion-${uuid()}`;
 
 	/**
 	 * This listens for the `setAppLanguage` event sent from the test language toggler when it is is connected to the DOM. It is used for the initial language when the input component loads.
@@ -129,13 +130,15 @@ export class OntarioAccordion {
 			const parsed = Array.isArray(this.accordionData) ? this.accordionData : JSON.parse(this.accordionData || '[]');
 
 			// Normalize and type-guard
-			this.internalAccordionData = (parsed || []).map((prop: any) => ({
-				label: prop?.label ?? '',
-				content: prop?.content ?? '',
-				accordionContentType: (prop?.accordionContentType ?? 'string') as 'string' | 'html',
-				isOpen: Boolean(prop?.isOpen),
-				ariaLabelText: prop?.ariaLabelText,
-			}));
+			this.internalAccordionData = parsed.length
+				? parsed.map((prop: Accordion) => ({
+						label: prop?.label ?? '',
+						content: prop?.content ?? '',
+						accordionContentType: (prop?.accordionContentType ?? 'string') as 'string' | 'html',
+						isOpen: Boolean(prop?.isOpen),
+						ariaLabelText: prop?.ariaLabelText,
+					}))
+				: [];
 
 			// Seed the openAccordionIndexes based on the isOpen properties
 			this.seedOpenIndexesFromItems();
@@ -145,7 +148,7 @@ export class OntarioAccordion {
 
 			this.emitAccordionChange({
 				openIndexes: this.openAccordionIndexes,
-				reason: 'init',
+				reason: AccordionChangeDetailReasons.Init,
 			});
 		} catch {
 			const message = new ConsoleMessageClass();
@@ -163,7 +166,7 @@ export class OntarioAccordion {
 
 			this.emitAccordionChange({
 				openIndexes: this.openAccordionIndexes,
-				reason: 'init',
+				reason: AccordionChangeDetailReasons.Init,
 			});
 		}
 	}
@@ -229,7 +232,7 @@ export class OntarioAccordion {
 		this.emitAccordionChange({
 			openIndexes: this.openAccordionIndexes,
 			changedIndex: index,
-			reason: 'toggle-one',
+			reason: AccordionChangeDetailReasons.ToggleOne,
 		});
 	}
 
@@ -250,7 +253,7 @@ export class OntarioAccordion {
 		this.emitAccordionChange({
 			openIndexes: this.openAccordionIndexes,
 			isBulk: true,
-			reason: 'toggle-all',
+			reason: AccordionChangeDetailReasons.ToggleAll,
 		});
 	}
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
@@ -74,6 +74,27 @@ expand-collapse-button='{ "expandAllSectionsLabel": "Expand All", "collapseAllSe
 | `collapseAllSectionsLabel` | The label for the 'Collapse all' button. | `string` |
 | `ariaLabelText`            | Alt text for the expand/close button.    | `string` |
 
+### AccordionChangeDetail
+
+This event detail type is emitted by the `accordionChange` event whenever an individual accordion item's open state changes. It provides context about what changed, which indexes are open, and why the event occurred.
+
+| Property       | Description                                                   | Type                                                               |
+| -------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
+| `openIndexes`  | Array of indexes currently open.                              | `number[]`                                                         |
+| `changedIndex` | The index that was just toggled (if applicable).              | `number`                                                           | `undefined` |
+| `isBulk`       | True if triggered by a “Expand All” or “Collapse All” action. | `boolean`                                                          | `undefined` |
+| `reason`       | Describes what triggered the event.                           | [`AccordionChangeDetailReason`](#accordionchangedetailreason-enum) |
+
+### AccordionChangeDetailReason (enum)
+
+This enum defines the possible values for the reason property in the event payload.
+
+| Enum Member | Value          | Description                                                 |
+| ----------- | -------------- | ----------------------------------------------------------- |
+| `Init`      | `'init'`       | Emitted when the component first initializes.               |
+| `ToggleOne` | `'toggle-one'` | Emitted when a single accordion item is toggled.            |
+| `ToggleAll` | `'toggle-all'` | Emitted when all accordion items are expanded or collapsed. |
+
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
 The Ontario Accordion component supports multiple languages via the `language` prop, which controls the text used in translatable UI elements (e.g., button labels). If no language is explicitly passed, it defaults to English (`'en'`).


### PR DESCRIPTION
This MR updates the `ontario-accordion` component to simplify state handling and improve clarity. Specifically, it removes the global `isOpen` prop and ensures that only the per-accordion `isOpen` property inside accordionData determines which accordions are initially open.

## Changes
- Removed global `isOpen` prop
   - Initial open state is seeded only from `accordionData[i].isOpen`
- Added new `seedOpenIndexesFromItems()` function
   - Seeds `openAccordionIndexes` directly from single accordion `isOpen` flags.
- Updated `parseAccordionData()` Watch function
   - Normalizes input and applies default values for a`ccordionContentType` and `isOpen`.
   - Calls `seedOpenIndexesFromItems()` to establish initial open state.
   - Improves error handling and consistency when parsing JSON input.
- Updated class and aria handling
- **Expand/Collapse all button**: Logic remains the same, but now correctly reflects state seeded from per-accordion `isOpen`.
- Updated class and aria handling
    - When open:
        - accordion wrapper `<div>` gets `open` class added
        - accordion heading gets `ontario-accordion__heading ontario-expander--active` class added
        - accordion button aria-expanded value is set to `true`
        - accordion content `<section>` gets `ontario-accordion__content ontario-expander__content--opened` class added
    - When closed: correct “closed” classes/attributes are applied
-  Expand/Collapse all button
   - Still toggles all panels, but logic now integrates with per-accordion `isOpen` state
   - Updates labels and aria-expanded consistently
- Utility cleanup
   - Improved readability of seeded indexes logic
   - Maintains unique id generation via new `uidPrefix` state


## Testing
- Verified that items marked `isOpen: true` in `accordionData` render expanded initially.
- Verified that toggling an individual accordion updates classes/aria attributes correctly.
- Verified that Expand/Collapse all reflects current state and toggles all items as expected.