### PR TITLE
Add extract-git-issues utility for release issue collection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,6 @@ name: Build
 on:
   workflow_call:
     inputs:
-      node-version:
-        required: true
-        type: number
       build-artifacts-name:
         required: true
         type: string
@@ -32,10 +29,10 @@ jobs:
         uses: pnpm/action-setup@v4
 
       # Setup Node.js
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     name: Build
     uses: ./.github/workflows/build.yml # Path to the reusable workflow file
     with:
-      node-version: 22
       build-artifacts-name: 'build-artifacts'
       docs-artifacts-name: 'docs-artifacts'
 
@@ -28,7 +27,6 @@ jobs:
       actions: read
       checks: write
     with:
-      node-version: 22
       build-artifacts-name: ${{ needs.build.outputs.build-artifacts-name }}
 
   # Publish packages and release artifacts on release branches.
@@ -38,7 +36,6 @@ jobs:
     uses: ./.github/workflows/publish-packages.yml # Path to the reusable workflow file
     if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
     with:
-      node-version: 22
       build-artifacts-name: ${{ needs.build.outputs.build-artifacts-name }}
     secrets: inherit
     permissions:
@@ -55,7 +52,6 @@ jobs:
     uses: ./.github/workflows/sync-docs-to-docusaurus.yml
     if: ${{ success() && needs.publish-packages.outputs.release_tag != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
     with:
-      node-version: 22
       docs-artifacts-name: ${{ needs.build.outputs.docs-artifacts-name }}
       release_tag: ${{ needs.publish-packages.outputs.release_tag }}
     secrets: inherit

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,9 +3,6 @@ name: Publish Packages
 on:
   workflow_call:
     inputs:
-      node-version:
-        required: true
-        type: number
       build-artifacts-name:
         required: true
         type: string
@@ -29,10 +26,10 @@ jobs:
         uses: pnpm/action-setup@v4
 
       # Setup Node.js
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -3,9 +3,6 @@ name: Sync Docs to External Docusaurus Repo
 on:
   workflow_call:
     inputs:
-      node-version:
-        required: true
-        type: string
       docs-artifacts-name:
         required: true
         type: string
@@ -44,10 +41,10 @@ jobs:
           run_install: false
 
       # Setup Node.js
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test
 on:
   workflow_call:
     inputs:
-      node-version:
-        required: true
-        type: number
       build-artifacts-name:
         required: true
         type: string
@@ -20,10 +17,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 
@@ -67,10 +64,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 
@@ -136,10 +133,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 
@@ -205,10 +202,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node.js ${{ inputs.node-version }}
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 engine-strict=true
-node-version=22.14.0
+node-version=22.22.0
 link-workspace-packages=true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 # Ontario Design System Components
 
+[![Node.js](https://img.shields.io/badge/node-22.22.0-339933?logo=node.js&logoColor=white)](./.nvmrc)
+[![pnpm](https://img.shields.io/github/package-json/packageManager/ongov/ontario-design-system?label=pnpm&logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![Stencil](https://img.shields.io/github/package-json/dependency-version/ongov/ontario-design-system/%40stencil%2Fcore?filename=packages/ontario-design-system-component-library/package.json&label=stencil&logo=stencil)](https://stenciljs.com/)
+[![TypeScript](https://img.shields.io/github/package-json/dependency-version/ongov/ontario-design-system/dev/typescript?filename=packages/ontario-design-system-component-library/package.json&label=typescipt&logo=typescript)](https://www.typescriptlang.org/)
+
 This project contains the Ontario Design System Web Components and npm packages.
 
 Web Components provide strong encapsulation for reusable components that can be integrated into web applications.
+
+Tool versions are standardized at the repo root: Node via [`.nvmrc`](./.nvmrc), and package manager/engine ranges via [`package.json`](./package.json).
 
 ## Documentation
 

--- a/documentation/internal-documentation/setup-guide.md
+++ b/documentation/internal-documentation/setup-guide.md
@@ -2,8 +2,8 @@
 
 ## 1. System Requirements
 
-- **[Node.js](https://nodejs.org/en/download):** v22.22.0
-- **[PNPM](https://pnpm.io/installation):** v10.2.0
+- **[Node.js](https://nodejs.org/en/download):** use the version pinned in [`/.nvmrc`](../../.nvmrc) (currently `v22.22.0`)
+- **[PNPM](https://pnpm.io/installation):** use the version/range in [`/package.json`](../../package.json) (`packageManager` currently `pnpm@10.2.0`)
 
 ## 2. Project Structure Overview
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@types/node": "^22.12.0",
 		"bash-color": "^0.0.4",
 		"commander": "^11.0.0",
+		"dotenv": "^16.4.5",
 		"husky": "^8.0.2",
 		"js-yaml": "^4.1.0",
 		"lerna": "^8.1.9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
 		"test:update-snapshots:docker": "pnpm -r run test:update-snapshots:docker",
 		"test:all": "pnpm run test:unit && pnpm run test:e2e"
 	},
+	"engines": {
+		"node": ">=22.22.0 <23",
+		"pnpm": ">=10.2.0 <11"
+	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.5.0",
 		"@commitlint/config-conventional": "^19.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       commander:
         specifier: ^11.0.0
         version: 11.1.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.7
       husky:
         specifier: ^8.0.2
         version: 8.0.3
@@ -456,7 +459,7 @@ importers:
         version: 3.4.2
       rollup-plugin-dotenv:
         specifier: ^0.5.1
-        version: 0.5.1(rollup@4.55.2)
+        version: 0.5.1(rollup@4.57.0)
       sass-embedded:
         specifier: ^1.89.2
         version: 1.93.2
@@ -3384,8 +3387,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.57.0':
+    resolution: {integrity: sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.55.2':
     resolution: {integrity: sha512-eXBg7ibkNUZ+sTwbFiDKou0BAckeV6kIigK7y5Ko4mB/5A1KLhuzEKovsmfvsL8mQorkoincMFGnQuIT92SKqA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.0':
+    resolution: {integrity: sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==}
     cpu: [arm64]
     os: [android]
 
@@ -3399,6 +3412,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.57.0':
+    resolution: {integrity: sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.34.9':
     resolution: {integrity: sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==}
     cpu: [x64]
@@ -3409,8 +3427,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-x64@4.57.0':
+    resolution: {integrity: sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rollup/rollup-freebsd-arm64@4.55.2':
     resolution: {integrity: sha512-WDUPLUwfYV9G1yxNRJdXcvISW15mpvod1Wv3ok+Ws93w1HjIVmCIFxsG2DquO+3usMNCpJQ0wqO+3GhFdl6Fow==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-arm64@4.57.0':
+    resolution: {integrity: sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==}
     cpu: [arm64]
     os: [freebsd]
 
@@ -3419,13 +3447,28 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-x64@4.57.0':
+    resolution: {integrity: sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.55.2':
     resolution: {integrity: sha512-AEXMESUDWWGqD6LwO/HkqCZgUE1VCJ1OhbvYGsfqX2Y6w5quSXuyoy/Fg3nRqiwro+cJYFxiw5v4kB2ZDLhxrw==}
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.0':
+    resolution: {integrity: sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.55.2':
     resolution: {integrity: sha512-ZV7EljjBDwBBBSv570VWj0hiNTdHt9uGznDtznBB4Caj3ch5rgD4I2K1GQrtbvJ/QiB+663lLgOdcADMNVC29Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.0':
+    resolution: {integrity: sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==}
     cpu: [arm]
     os: [linux]
 
@@ -3439,6 +3482,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.57.0':
+    resolution: {integrity: sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
@@ -3449,8 +3497,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.57.0':
+    resolution: {integrity: sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-loong64-gnu@4.55.2':
     resolution: {integrity: sha512-gi21faacK+J8aVSyAUptML9VQN26JRxe484IbF+h3hpG+sNVoMXPduhREz2CcYr5my0NE3MjVvQ5bMKX71pfVA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.0':
+    resolution: {integrity: sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==}
     cpu: [loong64]
     os: [linux]
 
@@ -3459,8 +3517,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-loong64-musl@4.57.0':
+    resolution: {integrity: sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-ppc64-gnu@4.55.2':
     resolution: {integrity: sha512-rPyuLFNoF1B0+wolH277E780NUKf+KoEDb3OyoLbAO18BbeKi++YN6gC/zuJoPPDlQRL3fIxHxCxVEWiem2yXw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.0':
+    resolution: {integrity: sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==}
     cpu: [ppc64]
     os: [linux]
 
@@ -3469,8 +3537,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-musl@4.57.0':
+    resolution: {integrity: sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.55.2':
     resolution: {integrity: sha512-i+sGeRGsjKZcQRh3BRfpLsM3LX3bi4AoEVqmGDyc50L6KfYsN45wVCSz70iQMwPWr3E5opSiLOwsC9WB4/1pqg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.0':
+    resolution: {integrity: sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==}
     cpu: [riscv64]
     os: [linux]
 
@@ -3479,8 +3557,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-musl@4.57.0':
+    resolution: {integrity: sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.55.2':
     resolution: {integrity: sha512-68gHUK/howpQjh7g7hlD9DvTTt4sNLp1Bb+Yzw2Ki0xvscm2cOdCLZNJNhd2jW8lsTPrHAHuF751BygifW4bkQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.0':
+    resolution: {integrity: sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==}
     cpu: [s390x]
     os: [linux]
 
@@ -3494,6 +3582,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.57.0':
+    resolution: {integrity: sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
@@ -3504,13 +3597,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.57.0':
+    resolution: {integrity: sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-openbsd-x64@4.55.2':
     resolution: {integrity: sha512-cT2MmXySMo58ENv8p6/O6wI/h/gLnD3D6JoajwXFZH6X9jz4hARqUhWpGuQhOgLNXscfZYRQMJvZDtWNzMAIDw==}
     cpu: [x64]
     os: [openbsd]
 
+  '@rollup/rollup-openbsd-x64@4.57.0':
+    resolution: {integrity: sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==}
+    cpu: [x64]
+    os: [openbsd]
+
   '@rollup/rollup-openharmony-arm64@4.55.2':
     resolution: {integrity: sha512-sZnyUgGkuzIXaK3jNMPmUIyJrxu/PjmATQrocpGA1WbCPX8H5tfGgRSuYtqBYAvLuIGp8SPRb1O4d1Fkb5fXaQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-openharmony-arm64@4.57.0':
+    resolution: {integrity: sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -3524,13 +3632,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.57.0':
+    resolution: {integrity: sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.55.2':
     resolution: {integrity: sha512-GvJ03TqqaweWCigtKQVBErw2bEhu1tyfNQbarwr94wCGnczA9HF8wqEe3U/Lfu6EdeNP0p6R+APeHVwEqVxpUQ==}
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.57.0':
+    resolution: {integrity: sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-gnu@4.55.2':
     resolution: {integrity: sha512-KvXsBvp13oZz9JGe5NYS7FNizLe99Ny+W8ETsuCyjXiKdiGrcz2/J/N8qxZ/RSwivqjQguug07NLHqrIHrqfYw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.0':
+    resolution: {integrity: sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==}
     cpu: [x64]
     os: [win32]
 
@@ -3541,6 +3664,11 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.55.2':
     resolution: {integrity: sha512-xNO+fksQhsAckRtDSPWaMeT1uIM+JrDRXlerpnWNXhn1TdB3YZ6uKBMBTKP0eX9XtYEP978hHk1f8332i2AW8Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.0':
+    resolution: {integrity: sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==}
     cpu: [x64]
     os: [win32]
 
@@ -5479,6 +5607,10 @@ packages:
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-newline@3.1.0:
@@ -9528,6 +9660,11 @@ packages:
 
   rollup@4.55.2:
     resolution: {integrity: sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.57.0:
+    resolution: {integrity: sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -14286,12 +14423,12 @@ snapshots:
     optionalDependencies:
       rollup: 4.55.2
 
-  '@rollup/plugin-replace@5.0.7(rollup@4.55.2)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.57.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.55.2)
+      '@rollup/pluginutils': 5.1.4(rollup@4.57.0)
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.55.2
+      rollup: 4.57.0
 
   '@rollup/pluginutils@5.1.4(rollup@4.55.2)':
     dependencies:
@@ -14301,10 +14438,24 @@ snapshots:
     optionalDependencies:
       rollup: 4.55.2
 
+  '@rollup/pluginutils@5.1.4(rollup@4.57.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.57.0
+
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.57.0':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.55.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.34.9':
@@ -14313,22 +14464,40 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.55.2':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.57.0':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.34.9':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.55.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.57.0':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.55.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.55.2':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-musleabihf@4.55.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
@@ -14337,31 +14506,58 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-loong64-gnu@4.55.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-loong64-musl@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-gnu@4.55.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-musl@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.55.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.55.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
@@ -14370,16 +14566,28 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.57.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.34.9':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.55.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.57.0':
+    optional: true
+
   '@rollup/rollup-openbsd-x64@4.55.2':
     optional: true
 
+  '@rollup/rollup-openbsd-x64@4.57.0':
+    optional: true
+
   '@rollup/rollup-openharmony-arm64@4.55.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
@@ -14388,16 +14596,28 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.55.2':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.57.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.55.2':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.57.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-gnu@4.55.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.55.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.0':
     optional: true
 
   '@rollup/wasm-node@4.32.0':
@@ -16576,6 +16796,9 @@ snapshots:
     optional: true
 
   detect-libc@2.0.3:
+    optional: true
+
+  detect-libc@2.1.2:
     optional: true
 
   detect-newline@3.1.0: {}
@@ -20081,7 +20304,7 @@ snapshots:
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
-      detect-libc: 2.0.3
+      detect-libc: 2.1.2
     optional: true
 
   node-gyp@10.3.1:
@@ -20984,7 +21207,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -21505,11 +21728,11 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.58
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.58
 
-  rollup-plugin-dotenv@0.5.1(rollup@4.55.2):
+  rollup-plugin-dotenv@0.5.1(rollup@4.57.0):
     dependencies:
-      '@rollup/plugin-replace': 5.0.7(rollup@4.55.2)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.57.0)
       dotenv: 16.4.7
-      rollup: 4.55.2
+      rollup: 4.57.0
 
   rollup-plugin-dts@6.3.0(rollup@4.55.2)(typescript@5.9.3):
     dependencies:
@@ -21548,6 +21771,37 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.55.2
       '@rollup/rollup-win32-x64-gnu': 4.55.2
       '@rollup/rollup-win32-x64-msvc': 4.55.2
+      fsevents: 2.3.3
+
+  rollup@4.57.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.0
+      '@rollup/rollup-android-arm64': 4.57.0
+      '@rollup/rollup-darwin-arm64': 4.57.0
+      '@rollup/rollup-darwin-x64': 4.57.0
+      '@rollup/rollup-freebsd-arm64': 4.57.0
+      '@rollup/rollup-freebsd-x64': 4.57.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.0
+      '@rollup/rollup-linux-arm64-gnu': 4.57.0
+      '@rollup/rollup-linux-arm64-musl': 4.57.0
+      '@rollup/rollup-linux-loong64-gnu': 4.57.0
+      '@rollup/rollup-linux-loong64-musl': 4.57.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.0
+      '@rollup/rollup-linux-ppc64-musl': 4.57.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.0
+      '@rollup/rollup-linux-riscv64-musl': 4.57.0
+      '@rollup/rollup-linux-s390x-gnu': 4.57.0
+      '@rollup/rollup-linux-x64-gnu': 4.57.0
+      '@rollup/rollup-linux-x64-musl': 4.57.0
+      '@rollup/rollup-openbsd-x64': 4.57.0
+      '@rollup/rollup-openharmony-arm64': 4.57.0
+      '@rollup/rollup-win32-arm64-msvc': 4.57.0
+      '@rollup/rollup-win32-ia32-msvc': 4.57.0
+      '@rollup/rollup-win32-x64-gnu': 4.57.0
+      '@rollup/rollup-win32-x64-msvc': 4.57.0
       fsevents: 2.3.3
 
   router@2.2.0:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,29 @@
 # Ontario Design System Scripts
 
-This folder serves as a collection of project-wide scripts that provide shared functionality and utilities used throughout the application. By centralizing these scripts, the project ensures consistency, reusability, and easier maintenance across different components and features.
+This folder serves as a collection of project-wide scripts that provide shared functionality and utilities used throughout the application. By centralising these scripts, the project ensures consistency, reusability, and easier maintenance across different components and features.
+
+## extract-git-issues.js
+
+A utility script that extracts Jira issue keys from git commit subjects since a specified tag. If a Jira instance URL is provided, it outputs Jira links. If Jira credentials are also provided, it fetches issue titles from Jira.
+
+### Usage
+
+```sh
+node extract-git-issues.js --tag v1.1.0
+```
+
+#### Options
+
+- `-t, --tag <string>`: Release tag name, e.g. `v1.1.0` (or `RELEASE_TAG_NAME`)
+- `-k, --projectKey <string>`: Limit matches to a specific Jira project key, e.g. `ODS`
+- `--no-unique`: Keep duplicate issue keys
+- `--no-sort`: Keep the original order from git output
+- `-u, --username <string>`: Jira username for title lookup (or `JIRA_USERNAME`)
+- `-p, --personalAccessToken <string>`: Jira personal access token for title lookup (or `JIRA_PERSONAL_ACCESS_TOKEN`)
+- `-i, --jiraInstanceUrl <string>`: Jira base URL (or `JIRA_INSTANCE_URL`)
+- `-c, --date`: Use the tag date (`git log --since`) instead of tag-to-HEAD range
+- `-j, --json`: Output as JSON (`issueId`, `issueUrl`, and optional `issueTitle`)
+- `-d, --debug`: Enable debug mode
 
 ## Docker test runner scripts
 

--- a/scripts/extract-git-issues.js
+++ b/scripts/extract-git-issues.js
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+const { program } = require('commander');
+const { promisify } = require('util');
+const execFile = promisify(require('child_process').execFile);
+const colour = require('bash-color');
+require('dotenv').config();
+
+const defaultIssuePattern = /\b[A-Z][A-Z0-9]+-\d+\b/g;
+
+/**
+ * Escape regex control characters in a user-supplied string.
+ *
+ * @param {string} value String to escape for safe regex interpolation.
+ * @returns {string} Escaped string.
+ */
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Build a Jira issue-key regex.
+ *
+ * @param {string | undefined} projectKey Optional Jira project key (e.g. `DS`).
+ * @returns {RegExp} Global regex used to extract issue keys.
+ */
+const buildIssuePattern = (projectKey) => {
+	// Match any Jira-style key by default, or constrain to one project key.
+	if (!projectKey) return defaultIssuePattern;
+	const key = escapeRegExp(projectKey.toUpperCase());
+	return new RegExp(`\\b${key}-\\d+\\b`, 'g');
+};
+
+/**
+ * Optionally de-duplicate and sort extracted issue keys.
+ *
+ * @param {string[]} items Issue keys.
+ * @param {{ unique: boolean; sort: boolean }} options Normalisation options.
+ * @returns {string[]} Normalised issue keys.
+ */
+const normaliseList = (items, { unique, sort }) => {
+	// Keep deduplication and ordering configurable for release-note workflows.
+	let output = items;
+	if (unique) output = [...new Set(output)];
+	if (sort) output = [...output].sort();
+	return output;
+};
+
+/**
+ * Run a git command safely without shell interpolation.
+ *
+ * @param {string[]} args Git CLI arguments.
+ * @returns {Promise<string>} Command stdout.
+ */
+async function runGit(args) {
+	const execResults = await execFile('git', args);
+	return execResults.stdout;
+}
+
+/**
+ * Fetch commit subjects between a tag and HEAD.
+ *
+ * @param {string} tagName Tag used as the lower bound.
+ * @returns {Promise<string[]>} Commit subject lines.
+ */
+async function getCommitSubjectsSinceTag(tagName) {
+	// Default mode: compare the provided tag with HEAD.
+	const gitOutput = await runGit(['log', `${tagName}..HEAD`, '--pretty=format:%s']);
+	return gitOutput.split('\n').filter(Boolean);
+}
+
+/**
+ * Fetch commit subjects since the timestamp of a tag.
+ *
+ * @param {string} tagName Tag used to derive the start date.
+ * @returns {Promise<string[]>} Commit subject lines.
+ */
+async function getCommitSubjectsSinceTagDate(tagName) {
+	// Optional mode: include all commits since the tag timestamp.
+	const tagDateOutput = await runGit(['log', '-1', '--format=%ai', tagName]);
+	const tagDate = tagDateOutput.trim();
+	const gitOutput = await runGit(['log', `--since=${tagDate}`, '--pretty=format:%s']);
+	return gitOutput.split('\n').filter(Boolean);
+}
+
+/**
+ * Extract Jira issue keys from commit subjects.
+ *
+ * @param {string[]} subjects Commit subject lines.
+ * @param {RegExp} pattern Regex used for matching issue keys.
+ * @returns {string[]} Matched issue keys.
+ */
+function extractIssueKeys(subjects, pattern) {
+	const matches = [];
+	for (const subject of subjects) {
+		const subjectMatches = subject.match(pattern);
+		if (subjectMatches) matches.push(...subjectMatches);
+	}
+	return matches;
+}
+
+/**
+ * Look up a Jira issue summary via Jira REST API.
+ *
+ * @param {string} issueId Jira issue key.
+ * @param {{ jiraInstanceUrl: string; username: string; personalAccessToken: string; debug: boolean }} params Request options.
+ * @returns {Promise<string>} Jira issue summary text.
+ */
+async function getJiraIssueSummary(issueId, { jiraInstanceUrl, username, personalAccessToken, debug }) {
+	const issueUrl = `${jiraInstanceUrl}/rest/api/latest/issue/${issueId}`;
+	if (debug) console.log('Fetching Jira summary:', issueUrl);
+
+	// Jira Cloud accepts Basic auth using email/username + API token.
+	const authHeader = Buffer.from(`${username}:${personalAccessToken}`).toString('base64');
+	const response = await fetch(issueUrl, {
+		headers: {
+			Authorization: `Basic ${authHeader}`,
+			Accept: 'application/json',
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error(`Jira lookup failed for ${issueId} (${response.status})`);
+	}
+
+	const payload = await response.json();
+	return payload.fields?.summary ?? '';
+}
+
+/**
+ * Build output data for one issue key, with optional Jira enrichment.
+ *
+ * @param {string} issueId Jira issue key.
+ * @param {{ jiraInstanceUrl?: string; username?: string; personalAccessToken?: string; debug: boolean }} options Script options.
+ * @returns {Promise<{ issueId: string; issueUrl: string | null; issueTitle: string | null }>} Output object for formatting.
+ */
+async function buildIssueInfo(issueId, options) {
+	const issueUrl = options.jiraInstanceUrl ? `${options.jiraInstanceUrl}/browse/${issueId}` : null;
+	if (!options.username || !options.personalAccessToken) {
+		// Keep key-only output when Jira credentials are not provided.
+		return { issueId, issueUrl, issueTitle: null };
+	}
+
+	try {
+		const issueTitle = await getJiraIssueSummary(issueId, options);
+		return { issueId, issueUrl, issueTitle };
+	} catch (error) {
+		console.error(colour.yellow(error.message || String(error)));
+		return { issueId, issueUrl, issueTitle: null };
+	}
+}
+
+/**
+ * Format a single issue row for markdown-friendly output.
+ *
+ * @param {{ issueId: string; issueUrl: string | null; issueTitle: string | null }} issueInfo Issue output data.
+ * @returns {string} Formatted output line.
+ */
+function formatIssueOutput(issueInfo) {
+	if (!issueInfo.issueUrl) return `- ${issueInfo.issueId}`;
+	if (issueInfo.issueTitle) return `- [${issueInfo.issueId}](${issueInfo.issueUrl}): ${issueInfo.issueTitle}`;
+	return `- [${issueInfo.issueId}](${issueInfo.issueUrl})`;
+}
+
+program
+	.description(
+		'Extract Jira issue keys from git commit subjects starting from a specific tag to HEAD.\nNote: This operates on the current git branch.',
+	)
+	.requiredOption(
+		'-t, --tag <string>',
+		`Release tag name, e.g. v1.1.0. Can also be set via ${colour.green('RELEASE_TAG_NAME')}.`,
+		process.env['RELEASE_TAG_NAME'],
+	)
+	.option('-k, --projectKey <string>', 'Limit matches to a specific Jira project key, e.g. ODS.')
+	.option('--no-unique', 'Do not de-duplicate issue keys.')
+	.option('--no-sort', 'Do not sort issue keys alphabetically.')
+	.option(
+		'-u, --username <string>',
+		`Jira username for issue title lookup. Can also be set via ${colour.green('JIRA_USERNAME')}.`,
+		process.env['JIRA_USERNAME'],
+	)
+	.option(
+		'-p, --personalAccessToken <string>',
+		`Jira personal access token for issue title lookup. Can also be set via ${colour.green('JIRA_PERSONAL_ACCESS_TOKEN')}.`,
+		process.env['JIRA_PERSONAL_ACCESS_TOKEN'],
+	)
+	.option(
+		'-i, --jiraInstanceUrl <string>',
+		`Jira base URL. Can also be set via ${colour.green('JIRA_INSTANCE_URL')}.`,
+		process.env['JIRA_INSTANCE_URL'],
+	)
+	.option('-c, --date', 'Use the date of the tag rather than the commit range to HEAD.')
+	.option('-j, --json', 'Output results as JSON.')
+	.option('-d, --debug', 'Enable debug mode.');
+
+program.parse();
+
+const options = program.opts();
+
+(async () => {
+	try {
+		if (options.debug) console.log('Processing tag:', options.tag);
+
+		// Switch between commit-range mode and tag-date mode.
+		const subjects = options.date
+			? await getCommitSubjectsSinceTagDate(options.tag)
+			: await getCommitSubjectsSinceTag(options.tag);
+		if (options.debug) console.log('Commit subjects:', subjects.length);
+
+		const pattern = buildIssuePattern(options.projectKey);
+		const issueKeys = extractIssueKeys(subjects, pattern);
+		const processedKeys = normaliseList(issueKeys, {
+			unique: options.unique,
+			sort: options.sort,
+		});
+
+		if (processedKeys.length === 0) {
+			console.error(colour.yellow('No issue keys found for the specified range.'));
+			return;
+		}
+
+		if ((options.username || options.personalAccessToken) && !options.jiraInstanceUrl) {
+			throw new Error('A Jira instance URL is required when using Jira credentials.');
+		}
+
+		const issueInfoList = await Promise.all(processedKeys.map((issueId) => buildIssueInfo(issueId, options)));
+
+		if (options.json) {
+			console.log(JSON.stringify(issueInfoList, null, 2));
+			return;
+		}
+
+		console.log(issueInfoList.map(formatIssueOutput).join('\n'));
+	} catch (error) {
+		console.error(colour.red(error.message || String(error)));
+		process.exitCode = 1;
+	}
+})();


### PR DESCRIPTION
## Summary
This PR adds a new script to extract Jira issue keys from git commit subjects since a specified release tag.

### What’s included
- Added `scripts/extract-git-issues.js`
- Added usage docs to `scripts/README.md`
- Added `dotenv` dependency updates in:
  - `package.json`
  - `pnpm-lock.yaml`

## Behaviour
- Extracts Jira-style issue keys from commit subjects.
- Supports:
  - `--tag` (required)
  - `--projectKey` filtering
  - `--no-unique` and `--no-sort`
  - `--date` mode (uses tag timestamp with `git log --since`)
  - `--json` output
  - optional Jira URL/title enrichment via credentials

## Notes
- Script works on the current git branch.
- Jira title lookup is optional; key/link output still works without credentials.
