### PR TITLE
Align contribution docs and improve fork PR test reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           path: packages/ontario-design-system-component-library/playwright-report
 
       - name: Publish Stencil Playwright E2E Test Results
-        if: ${{ (success() || failure()) && (github.event.pull_request.head.repo.fork == false) }}
+        if: ${{ success() || failure() }}
         uses: dorny/test-reporter@v1
         with:
           name: Stencil Playwright E2E Tests
@@ -177,7 +177,7 @@ jobs:
           path: packages/app-nextjs/playwright-report
 
       - name: Publish Next.js Playwright VRT Results
-        if: ${{ (success() || failure()) && (github.event.pull_request.head.repo.fork == false) }}
+        if: ${{ success() || failure() }}
         uses: dorny/test-reporter@v1
         with:
           name: Next.js Playwright VRT Tests
@@ -246,7 +246,7 @@ jobs:
           path: packages/app-nextjs/playwright-report
 
       - name: Publish Next.js Playwright Next.js E2E Test Results
-        if: ${{ (success() || failure()) && (github.event.pull_request.head.repo.fork == false) }}
+        if: ${{ success() || failure() }}
         uses: dorny/test-reporter@v1
         with:
           name: Playwright Next.js E2E Tests

--- a/COMMIT-GUIDELINES.md
+++ b/COMMIT-GUIDELINES.md
@@ -6,6 +6,8 @@ By adhering to the Conventional Commit structure and following semantic versioni
 
 Happy Committing!
 
+For branch naming conventions, workflow expectations, and pull request guidance, refer to the [Contributing Guidelines](documentation/internal-documentation/contributing-guidelines.md).
+
 ## Commit messages
 
 Commit messages are the messages that accompany a commit and help to document the flow of the project history. A good commit message goes a long way to helping other developers (or even future you) trace how a project has progressed over time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ There is no required external branch naming convention.
 
 ## Commit Messages
 
-This repository follows Conventional Commits.
+This repository follows [Conventional Commits](https://www.conventionalcommits.org/).
+
 External contributors should follow the same commit message rules as internal contributors.
 
 Examples:
@@ -79,9 +80,10 @@ pnpm run test:e2e
 
 ## Code Standards
 
-- Follow existing patterns and naming conventions.
-- Use BEM and project SCSS guidance.
-- Keep changes focused and scoped.
+- Follow existing patterns, naming conventions, and architecture used in nearby files.
+- Use [BEM](https://getbem.com/introduction/) for SCSS class naming.
+- See internal team standards: [Contributing Guidelines: Code Standards](documentation/internal-documentation/contributing-guidelines.md#code-standards).
+- Keep changes focused and scoped to a single concern whenever possible.
 
 ## Release Notes Impact
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to Ontario Design System
+
+Thanks for contributing. This guide covers the minimum steps to get set up and submit changes.
+
+## Quick Start
+
+1. Clone the repository.
+2. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. Build all libraries to verify your environment:
+
+   ```bash
+   pnpm run build-libs
+   ```
+
+   _Optional alternative_: run `pnpm refresh` for the full refresh flow (`clean`, `install`, and `build-libs`) defined in `package.json`. This is not required for initial setup because it already includes `pnpm install`.
+
+4. Review key documentation:
+   - Setup: [Setup Guide](documentation/internal-documentation/setup-guide.md)
+   - Workflow and branching: [Contributing Guidelines](documentation/internal-documentation/contributing-guidelines.md)
+   - Commit messages: [Commit Guidelines](COMMIT-GUIDELINES.md)
+   - Package-specific docs: review each package README in [packages/](packages/) for local commands and conventions.
+
+## Branch Naming
+
+Internal team branches should use:
+
+`[your-name]/[branch-type]/[issue-number]-[description]`
+
+Examples:
+
+- `scott/feature/DS-123-add-tooltip-a11y-text`
+- `erin/bugfix/DS-456`
+
+## External Contributions (Forks)
+
+If you are contributing from outside the project team:
+
+1. Fork the repository to your own GitHub account.
+2. Create a descriptive branch in your fork (recommended), or contribute from your fork's default branch.
+3. Push your branch to your fork.
+4. Open a pull request from your fork branch to this repository's `develop` branch.
+
+There is no required external branch naming convention.
+
+## Commit Messages
+
+This repository follows Conventional Commits.
+External contributors should follow the same commit message rules as internal contributors.
+
+Examples:
+
+- `feat(ontario-button): add icon-only variant`
+- `fix(ontario-input): prevent duplicate error message`
+
+See full rules in [Commit Guidelines](COMMIT-GUIDELINES.md).
+
+## Testing
+
+Run tests before opening a pull request:
+
+```bash
+pnpm run test:unit
+pnpm run test:e2e
+```
+
+## Pull Requests
+
+1. Keep your branch up to date with `develop` (or `master` for hotfixes).
+2. Open a pull request with:
+   - A clear summary.
+   - A linked Jira issue (internal contributors) or relevant GitHub issue/context (external contributors).
+   - Testing notes.
+3. Request review from appropriate team members.
+
+## Code Standards
+
+- Follow existing patterns and naming conventions.
+- Use BEM and project SCSS guidance.
+- Keep changes focused and scoped.
+
+## Release Notes Impact
+
+Use an appropriate Conventional Commit type for the change. Not everything should be `feat` or `fix`.
+
+If your change should appear in release notes, use `feat` or `fix` with a clear subject line.
+
+For other valid commit types (for example `docs`, `chore`, `refactor`, `test`), see [Non `feat` or `fix` commit prefixes](COMMIT-GUIDELINES.md#non-feat-or-fix-commit-prefixes).

--- a/documentation/internal-documentation/contributing-guidelines.md
+++ b/documentation/internal-documentation/contributing-guidelines.md
@@ -25,7 +25,7 @@ For all other branches there are a few different types that can be used.
 
 | Branch Type | Description                                                                | Example                                         |
 | ----------- | -------------------------------------------------------------------------- | ----------------------------------------------- |
-| _feature_   | A branch that contains a feature, which is a significant work item/change. | `meaghan/feature/DS-122/create-table-component` |
+| _feature_   | A branch that contains a feature, which is a significant work item/change. | `meaghan/feature/DS-122-create-table-component` |
 | _bugfix_    | A branch that is based off a _Bug_ issue in Jira.                          | `erin/bugfix/DS-123`                            |
 | _hotfix_    | A branch that fixes an issue with production, similar to a _bugfix_.       | `kyle/hotfix/DS-124`                            |
 | _task_      | _Reserved for future use._                                                 | `matt/task/DS-125`                              |
@@ -36,8 +36,10 @@ For all other branches there are a few different types that can be used.
 The recommended naming convention for branches is,
 
 ```
-[your-name]/[branch-type]/[issue-number]/[description]
+[your-name]/[branch-type]/[issue-number]-[description]
 ```
+
+This format is for internal team branches in this repository.
 
 |                  |                                                |
 | ---------------- | ---------------------------------------------- |
@@ -46,7 +48,7 @@ The recommended naming convention for branches is,
 | `[issue-number]` | Jira issue number, DS-123                      |
 | `[description]`  | Short description of issue/branch (_optional_) |
 
-_Note_: Although the `description` is optional, it is recommended to help distinguish the branch from other branches once a number of them have been created.
+_Note_: Although the `description` is optional, it is recommended to help distinguish the branch from other branches once a number of them have been created. If included, append it to `issue-number` using a dash, for example `DS-123-update-button-styles`.
 
 ## Code Standards
 
@@ -56,7 +58,7 @@ This project uses [BEM](http://getbem.com/introduction/) methodology for SCSS cl
 
 This project follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) commit message structure. It is automatically linted using a [Husky](https://typicode.github.io/husky/) pre-commit script that validates the message format, ensuring that it follows the Conventional Commit structure along with a few rules (based off the [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) rule set).
 
-Learn more through the [commit guidelines documentation](../../COMMIT-GUIDELINES.MD).
+Learn more through the [commit guidelines documentation](../../COMMIT-GUIDELINES.md).
 
 ## Testing
 

--- a/documentation/internal-documentation/readme.md
+++ b/documentation/internal-documentation/readme.md
@@ -5,7 +5,7 @@ This guide is intended to help you understand the structure of the monorepo, set
 
 ## 🏗 **Monorepo Overview**
 
-This monorepo contains multiple projects that work together to deliver a cohesive design sytem. Below is a brief description of each project:
+This monorepo contains multiple projects that work together to deliver a cohesive design system. Below is a brief description of each project:
 
 ### 1. [Ontario Design System Design Tokens](../../packages/ontario-design-system-design-tokens)
 
@@ -85,5 +85,5 @@ If you run into any issues, please contact the development team. You can reach u
 3. **Create a Branch:** Create a new branch for your feature or bug fix. Information on branching can be found [here](./contributing-guidelines.md#branching).
 4. **Develop:** Make your changes, following the [coding guidelines and best practices](./contributing-guidelines.md#code-standards).
 5. **Test:** Run unit tests with `pnpm run test:unit` and E2E tests with `pnpm run test:e2e`.
-6. **Commit and Push:** [Commit your changes](./contributing-guidelines.md#-contributing-guidelines) and push your branch to the remote repository.
+6. **Commit and Push:** Follow the [commit guidelines](../../COMMIT-GUIDELINES.md), then push your branch to the remote repository.
 7. **Create a Pull Request:** Open a pull request for your branch and request a code review. Make sure to label your pull request.

--- a/documentation/internal-documentation/release-process.md
+++ b/documentation/internal-documentation/release-process.md
@@ -1,3 +1,9 @@
 # Release Process
 
 Coming Soon 🏗
+
+In the meantime:
+
+- Follow the [Contributing Guidelines](./contributing-guidelines.md) for workflow and branch standards.
+- Follow the [Commit Guidelines](../../COMMIT-GUIDELINES.md) for commit message requirements.
+- Start from the [Internal Documentation Index](./readme.md) for related setup and workflow guidance.

--- a/documentation/internal-documentation/setup-guide.md
+++ b/documentation/internal-documentation/setup-guide.md
@@ -8,7 +8,7 @@
 ## 2. Project Structure Overview
 
 - `/packages` — Contains all projects (component libraries, styles, tokens, examples, documentation)
-  - `/packages/app-web-components-documentation`, `/packages/ontario-design-system-developer-docs-internal` — Component library + internal developer documentation
+  - `/packages/app-web-components-documentation`, `/documentation/internal-documentation` — Component library + internal developer documentation
   - `/packages/ontario-design-system-design-tokens`, `/packages/ontario-design-system-global-styles`, `/packages/ontario-design-system-complete-styles` — Design system styles
   - `/packages/ontario-design-system-component-library`, `/packages/ontario-design-system-component-library-react`, `/packages/ontario-design-system-component-library-angular` — Component libraries
   - `/packages/app-angular`, `/packages/app-react` — Example projects
@@ -16,3 +16,5 @@
 ## 3. 🚀 Running the Project
 
 Information for running the monorepo and the individual projects within it can be found in the [main monorepo README](../../README.md).
+
+For branch workflow and coding standards, see the [Contributing Guidelines](./contributing-guidelines.md). For commit message standards, see the [Commit Guidelines](../../COMMIT-GUIDELINES.md).


### PR DESCRIPTION
## Summary
- align internal documentation links and branch naming guidance
- add a root `CONTRIBUTING.md` for internal and external contributors
- clarify external fork workflow and commit expectations
- remove fork-only restriction on Playwright test report publishing

## Details
- updated `documentation/internal-documentation/*` cross-links and wording consistency
- added bidirectional links between `COMMIT-GUIDELINES.md` and internal contributing docs
- added release-notes guidance for non-`feat`/`fix` commit prefixes in `CONTRIBUTING.md`
- updated `.github/workflows/test.yml` so fork PRs also publish Playwright report annotations
