### PR TITLE
Renovate cleanup: label-gated PR and issue checks for Renovate PRs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,10 +6,19 @@ on:
     - cron: '0 0 * * 0'
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
+  # React to Renovate PR activity so checkbox/label requests are processed quickly
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
 
 jobs:
   run-renovate:
     name: Run Renovate Bot
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,13 +14,18 @@ on:
       - synchronize
       - edited
       - labeled
+  # React to Dependency Dashboard checkbox edits on Renovate-labeled issues
+  issues:
+    types:
+      - edited
 
 jobs:
   run-renovate:
     name: Run Renovate Bot
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'renovate')
+    if: >
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'renovate')) &&
+      (github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'renovate'))
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
- trigger Renovate on relevant PR events (`opened`, `reopened`, `synchronize`, `edited`, `labeled`)
- trigger Renovate on issue edits to support Dependency Dashboard checkbox interactions
- gate PR/issue-triggered runs to only items labeled `renovate`
- result is Renovate PR checkboxes should respond to interactions as intended, but not every PR will trigger a Renovate run

## Why
This keeps Renovate responsive for explicit rebase/retry/dashboard actions while reducing workflow noise on non-Renovate activity.