### PR TITLE
DS-2610: export package metadata and improve Next.js onboarding

### DIFF
--- a/packages/ontario-design-system-component-library-react/README.md
+++ b/packages/ontario-design-system-component-library-react/README.md
@@ -14,6 +14,10 @@ This library was generated using Stencil's React output target dependency. It is
 
 This package targets React 19 and ships bindings that align with React 19's JSX/runtime expectations and tooling. React 18 is no longer supported by this package's peer dependencies.
 
+### Next.js App Router guide
+
+For Next.js-specific setup guidance, including SSR configuration and asset handling, use the official [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
+
 ## Installation and usage
 
 To find documentation on individual web components in this component library, please download and refer to our [component documentation](https://designsystem.ontario.ca/docs/documentation/for-developers/web-components.html#component-documentation).
@@ -72,6 +76,10 @@ You can now use the React components in your component and template files.
 	quote="Access to high-quality child care is an issue that impacts our entire society."
 ></OntarioBlockquote>
 ```
+
+### Next.js
+
+For Next.js App Router projects, follow the dedicated [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). Use the same Sass-based styles entry described above, and follow the guide for SSR-specific configuration and asset handling.
 
 ### Sass (optional)
 

--- a/packages/ontario-design-system-component-library-react/docs/framework-integrations/next-js-ssr/readme.md
+++ b/packages/ontario-design-system-component-library-react/docs/framework-integrations/next-js-ssr/readme.md
@@ -122,7 +122,7 @@ The Ontario Design System provides a global stylesheet that includes foundationa
 
 ### Install Global Styles Package (If Not Already Installed)
 
-The global styles package is typically installed as a transitive dependency of the component library. It its missing or you encounter style-related errors, install it directly:
+The global styles package is typically installed as a transitive dependency of the component library. If it is missing or you encounter style-related errors, install it directly:
 
 ```bash
 npm add @ongov/ontario-design-system-global-styles
@@ -157,6 +157,15 @@ function MyApp({ Component, pageProps }) {
 	return <Component {...pageProps} />;
 }
 export default MyApp;
+```
+
+If you need to override the asset base path used by the theme, create a local Sass wrapper and forward the global styles theme with a custom `$asset-base-path`.
+
+```scss
+// src/styles/ontario-theme.scss
+@forward 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/theme.scss' with (
+	$asset-base-path: '/assets'
+);
 ```
 
 ---

--- a/packages/ontario-design-system-component-library-react/package.json
+++ b/packages/ontario-design-system-component-library-react/package.json
@@ -30,6 +30,7 @@
 			"import": "./dist/react-component-lib/index.js",
 			"default": "./dist/react-component-lib/index.js"
 		},
+		"./package.json": "./package.json",
 		"./styles": {
 			"default": "./dist/styles/theme.scss"
 		},


### PR DESCRIPTION
## Summary

- add `./package.json` to the React package exports map
- surface the canonical Next.js App Router guide near the top of the React README
- align the React package and Next.js integration docs with the current supported Sass/global-styles setup

## Why

Some toolchains inspect package exports directly, so the React package should expose
its package metadata. The Next.js guidance also needs to be easier to find without
implying a compiled CSS path that has been deferred.

## Notes

- compiled CSS shipping and asset-path strategy was intentionally deferred after
  implementation review and will be handled as follow-up design work
