### PR TITLE
Fix broken component doc anchors

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
@@ -838,7 +838,7 @@ Note: `href` is optional for printerLink
 
 ### twoColumnOptions
 
-The columns in the twoColumn type (i.e., `column1` and `column2`) and in the threeColumn type (i.e., `column1`, `column2`, and `column3`) share the same structure (i.e [FooterColumnData](#FooterColumnData)) and can be configured according to website requirments.
+The columns in the twoColumn type (i.e., `column1` and `column2`) and in the threeColumn type (i.e., `column1`, `column2`, and `column3`) share the same structure (i.e [FooterColumnData](#footercolumndata)) and can be configured according to website requirments.
 
 <!-- prettier-ignore -->
 ```html
@@ -879,8 +879,8 @@ two-column-options='{
 
 | **Property name** | **Type**                                | **Description**                                            |
 | ----------------- | --------------------------------------- | ---------------------------------------------------------- |
-| `column1`         | `[FooterColumnData](#FooterColumnData)` | Title, body, links or button for the first footer column.  |
-| `column2`         | `[FooterColumnData](#FooterColumnData)` | Title, body, links or button for the second footer column. |
+| `column1`         | `[FooterColumnData](#footercolumndata)` | Title, body, links or button for the first footer column.  |
+| `column2`         | `[FooterColumnData](#footercolumndata)` | Title, body, links or button for the second footer column. |
 
 ### threeColumnOptions
 
@@ -923,11 +923,11 @@ two-column-options='{
 
 #### threeColumn object
 
-| **Property name** | **Type**                               | **Description**                                            |
-| ----------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `column1`         | `[FooterColumnData](FooterColumnData)` | Title, body, links or button for the first footer column.  |
-| `column2`         | `[FooterColumnData](FooterColumnData)` | Title, body, links or button for the second footer column. |
-| `column3`         | `[FooterColumnData](FooterColumnData)` | Title, body, links or button for the third footer column.  |
+| **Property name** | **Type**                                | **Description**                                            |
+| ----------------- | --------------------------------------- | ---------------------------------------------------------- |
+| `column1`         | `[FooterColumnData](#footercolumndata)` | Title, body, links or button for the first footer column.  |
+| `column2`         | `[FooterColumnData](#footercolumndata)` | Title, body, links or button for the second footer column. |
+| `column3`         | `[FooterColumnData](#footercolumndata)` | Title, body, links or button for the third footer column.  |
 
 ## Interfaces
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
@@ -12,7 +12,7 @@ Please refer to the [Ontario Design System](https://designsystem.ontario.ca/comp
 
 ## Configuration
 
-Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the search box component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
+Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the search box component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [example](#example) below for how to configure the component.
 
 ## Example
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
@@ -12,7 +12,7 @@ Please refer to the [Ontario Design System](https://designsystem.ontario.ca/comp
 
 ## Configuration
 
-Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the task component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
+Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the task component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Please see the [examples](#examples) below for how to configure the component.
 
 ## Examples
 


### PR DESCRIPTION
This PR fixes broken internal documentation anchors in the component source docs so future Docusaurus syncs do not reintroduce the issue.

Updates included:
- fix `FooterColumnData` anchor links in the footer docs
- fix the search-box example anchor reference
- remove the stale custom-property-types reference in the task docs