### PR TITLE
Enable docs repo auto-merge handoff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,12 @@ jobs:
 
       # Build the project
       - name: Build the project
+        id: build_project
         run: pnpm run build-libs
 
       # Upload build artifacts
       - name: Upload build artifacts
+        id: upload_build_artifacts
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.build-artifacts-name }} # Artifact name
@@ -61,8 +63,22 @@ jobs:
 
       # Upload docs artifact
       - name: Upload docs artifact
+        id: upload_docs_artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.docs-artifacts-name }}
           compression-level: 9 # Best compression
           path: packages/docusaurus/docs/
+
+      - name: Summarise build outputs
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Build'
+            echo ''
+            echo "Build artifacts name: \`${{ inputs.build-artifacts-name }}\`"
+            echo "Docs artifacts name: \`${{ inputs.docs-artifacts-name }}\`"
+            echo "Build step outcome: \`${{ steps.build_project.outcome }}\`"
+            echo "Build artifact upload outcome: \`${{ steps.upload_build_artifacts.outcome }}\`"
+            echo "Docs artifact upload outcome: \`${{ steps.upload_docs_artifact.outcome }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,16 @@ jobs:
           {
             echo '## Build'
             echo ''
-            echo "Build artifacts name: \`${{ inputs.build-artifacts-name }}\`"
-            echo "Docs artifacts name: \`${{ inputs.docs-artifacts-name }}\`"
-            echo "Build step outcome: \`${{ steps.build_project.outcome }}\`"
-            echo "Build artifact upload outcome: \`${{ steps.upload_build_artifacts.outcome }}\`"
-            echo "Docs artifact upload outcome: \`${{ steps.upload_docs_artifact.outcome }}\`"
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Repository | \`${{ github.repository }}\` |"
+            echo "| Event | \`${{ github.event_name }}\` |"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| SHA | \`${{ github.sha }}\` |"
+            echo "| Run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Build artifacts | \`${{ inputs.build-artifacts-name }}\` |"
+            echo "| Docs artifacts | \`${{ inputs.docs-artifacts-name }}\` |"
+            echo "| Build step | \`${{ steps.build_project.outcome }}\` |"
+            echo "| Build artifact upload | \`${{ steps.upload_build_artifacts.outcome }}\` |"
+            echo "| Docs artifact upload | \`${{ steps.upload_docs_artifact.outcome }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,18 +79,14 @@ jobs:
           {
             echo '## Build'
             echo ''
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Repository | \`${{ github.repository }}\` |"
-            echo "| Event | \`${{ github.event_name }}\` |"
-            echo "| Ref | \`${{ github.ref_name }}\` |"
-            echo "| SHA | \`${{ github.sha }}\` |"
-            echo "| Run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
-            echo "| Build artifacts | \`${{ inputs.build-artifacts-name }}\` |"
-            echo "| Docs artifacts | \`${{ inputs.docs-artifacts-name }}\` |"
-            echo "| Build artifact size | \`${build_size:-unknown}\` |"
-            echo "| Docs artifact size | \`${docs_size:-unknown}\` |"
-            echo "| Build step | \`${{ steps.build_project.outcome }}\` |"
-            echo "| Build artifact upload | \`${{ steps.upload_build_artifacts.outcome }}\` |"
-            echo "| Docs artifact upload | \`${{ steps.upload_docs_artifact.outcome }}\` |"
+            echo "| Repository | Event | Ref | SHA | Run | Build Step |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+            echo "| \`${{ github.repository }}\` | \`${{ github.event_name }}\` | \`${{ github.ref_name }}\` | \`${{ github.sha }}\` | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) | \`${{ steps.build_project.outcome }}\` |"
+            echo ''
+            echo '### Artifacts'
+            echo ''
+            echo "| Artifact | Name | Size | Upload |"
+            echo "| --- | --- | --- | --- |"
+            echo "| Build | \`${{ inputs.build-artifacts-name }}\` | \`${build_size:-unknown}\` | \`${{ steps.upload_build_artifacts.outcome }}\` |"
+            echo "| Docs | \`${{ inputs.docs-artifacts-name }}\` | \`${docs_size:-unknown}\` | \`${{ steps.upload_docs_artifact.outcome }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Summarise build outputs
         if: ${{ always() }}
         run: |
+          build_size="$(du -sh --exclude docusaurus packages 2>/dev/null | cut -f1)"
+          docs_size="$(du -sh packages/docusaurus/docs 2>/dev/null | cut -f1)"
+
           {
             echo '## Build'
             echo ''
@@ -85,6 +88,8 @@ jobs:
             echo "| Run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
             echo "| Build artifacts | \`${{ inputs.build-artifacts-name }}\` |"
             echo "| Docs artifacts | \`${{ inputs.docs-artifacts-name }}\` |"
+            echo "| Build artifact size | \`${build_size:-unknown}\` |"
+            echo "| Docs artifact size | \`${docs_size:-unknown}\` |"
             echo "| Build step | \`${{ steps.build_project.outcome }}\` |"
             echo "| Build artifact upload | \`${{ steps.upload_build_artifacts.outcome }}\` |"
             echo "| Docs artifact upload | \`${{ steps.upload_docs_artifact.outcome }}\` |"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     needs: ['build', 'test']
     name: Predict Release Tag
     uses: ./.github/workflows/predict-release-tag.yml
-    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow' || (github.event_name == 'pull_request' && github.event.pull_request.number == 207)) }}
+    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow') }}
     secrets: inherit
 
   # Publish packages and release artifacts on release branches.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,14 @@ jobs:
           {
             echo '## Enable Docs Auto-Merge'
             echo ''
-            echo "Released tag: \`${{ needs.publish-packages.outputs.release_tag }}\`"
-            echo "Docs PR: #${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}"
-            echo "PR operation: \`${{ needs.sync-docs-to-docusaurus.outputs.pull-request-operation }}\`"
-            echo "Auto-merge step outcome: \`${{ steps.enable_automerge.outcome }}\`"
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Repository | \`${{ github.repository }}\` |"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| Workflow run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Released tag | \`${{ needs.publish-packages.outputs.release_tag }}\` |"
+            echo "| Docs PR | [#${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}](${{ github.server_url }}/ongov/design-system-developer-documentation-site/pull/${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}) |"
+            echo "| PR operation | \`${{ needs.sync-docs-to-docusaurus.outputs.pull-request-operation }}\` |"
+            echo "| Auto-merge step | \`${{ steps.enable_automerge.outcome }}\` |"
+            echo "| Merge method | \`rebase\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,17 @@ jobs:
     with:
       build-artifacts-name: ${{ needs.build.outputs.build-artifacts-name }}
 
+  # Predict the next release tag before publishing so docs PRs can be prepared earlier.
+  predict-release-tag:
+    needs: ['build', 'test']
+    name: Predict Release Tag
+    uses: ./.github/workflows/predict-release-tag.yml
+    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
+    secrets: inherit
+
   # Publish packages and release artifacts on release branches.
   publish-packages: # Job defined in a separate file (publish-packages.yml)
-    needs: ['build', 'test']
+    needs: ['build', 'test', 'predict-release-tag']
     name: Publish Packages
     uses: ./.github/workflows/publish-packages.yml # Path to the reusable workflow file
     if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
@@ -47,13 +55,13 @@ jobs:
   # Sync generated documentation to Docusaurus.
   # Only sync docs when there is a release_tag (semantic-release produced a tag).
   sync-docs-to-docusaurus: # Job defined in a separate file (sync-docs-to-docusaurus.yml)
-    needs: ['build', 'publish-packages']
+    needs: ['build', 'predict-release-tag']
     name: Sync Docs to Docusaurus
     uses: ./.github/workflows/sync-docs-to-docusaurus.yml
-    if: ${{ success() && needs.publish-packages.outputs.release_tag != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
+    if: ${{ success() && needs.predict-release-tag.outputs.release_tag != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
     with:
       docs-artifacts-name: ${{ needs.build.outputs.docs-artifacts-name }}
-      release_tag: ${{ needs.publish-packages.outputs.release_tag }}
+      release_tag: ${{ needs.predict-release-tag.outputs.release_tag }}
     secrets: inherit
 
   enable-docs-automerge:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
     if: ${{ success() && needs.publish-packages.outputs.release_tag != '' && needs.sync-docs-to-docusaurus.outputs.pull-request-number != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
     steps:
       - name: Enable docs PR auto-merge
+        id: enable_automerge
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: >
@@ -79,3 +80,15 @@ jobs:
           --auto
           --rebase
           ${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}
+
+      - name: Summarise docs auto-merge handoff
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Enable Docs Auto-Merge'
+            echo ''
+            echo "Released tag: \`${{ needs.publish-packages.outputs.release_tag }}\`"
+            echo "Docs PR: #${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}"
+            echo "PR operation: \`${{ needs.sync-docs-to-docusaurus.outputs.pull-request-operation }}\`"
+            echo "Auto-merge step outcome: \`${{ steps.enable_automerge.outcome }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,19 @@ jobs:
       docs-artifacts-name: ${{ needs.build.outputs.docs-artifacts-name }}
       release_tag: ${{ needs.publish-packages.outputs.release_tag }}
     secrets: inherit
+
+  enable-docs-automerge:
+    needs: ['publish-packages', 'sync-docs-to-docusaurus']
+    name: Enable Docs Auto-Merge
+    runs-on: ubuntu-latest
+    if: ${{ success() && needs.publish-packages.outputs.release_tag != '' && needs.sync-docs-to-docusaurus.outputs.pull-request-number != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
+    steps:
+      - name: Enable docs PR auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: >
+          gh pr merge
+          --repo ongov/design-system-developer-documentation-site
+          --auto
+          --rebase
+          ${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ['master', 'alpha', 'beta']
+    branches: ['master', 'alpha', 'beta', 'scott/task/docs-automerge-workflow']
   pull_request: # Trigger on pull request events
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
     needs: ['build', 'test']
     name: Predict Release Tag
     uses: ./.github/workflows/predict-release-tag.yml
-    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
+    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow') }}
     secrets: inherit
 
   # Publish packages and release artifacts on release branches.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ['master', 'alpha', 'beta', 'scott/task/docs-automerge-workflow']
+    branches: ['master', 'alpha', 'beta']
   pull_request: # Trigger on pull request events
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
     needs: ['build', 'test']
     name: Predict Release Tag
     uses: ./.github/workflows/predict-release-tag.yml
-    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow') }}
+    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta') }}
     secrets: inherit
 
   # Publish packages and release artifacts on release branches.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     needs: ['build', 'test']
     name: Predict Release Tag
     uses: ./.github/workflows/predict-release-tag.yml
-    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow') }}
+    if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/alpha' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/scott/task/docs-automerge-workflow' || (github.event_name == 'pull_request' && github.event.pull_request.number == 207)) }}
     secrets: inherit
 
   # Publish packages and release artifacts on release branches.

--- a/.github/workflows/predict-release-tag.yml
+++ b/.github/workflows/predict-release-tag.yml
@@ -1,0 +1,61 @@
+name: Predict Release Tag
+
+on:
+  workflow_call:
+    outputs:
+      release_tag:
+        description: 'The predicted git tag for the next release'
+        value: ${{ jobs.predict.outputs.release_tag }}
+
+jobs:
+  predict:
+    name: Predict Release Tag
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.predict.outputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Predict release tag
+        id: predict
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          node <<'EOF'
+          const semanticRelease = require('semantic-release');
+          const fs = require('fs');
+
+          (async () => {
+            const result = await semanticRelease(
+              {
+                dryRun: true,
+                ci: false,
+              },
+              {
+                cwd: process.cwd(),
+                env: process.env,
+                stdout: process.stdout,
+                stderr: process.stderr,
+              },
+            );
+
+            const releaseTag = result && result.nextRelease ? result.nextRelease.gitTag : '';
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=${releaseTag}\n`);
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          EOF

--- a/.github/workflows/predict-release-tag.yml
+++ b/.github/workflows/predict-release-tag.yml
@@ -34,3 +34,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: pnpm run semantic-release -- --dry-run
+
+      - name: Summarise predicted release tag
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Predict Release Tag'
+            echo ''
+            if [ -n "${{ steps.predict.outputs.release_tag }}" ]; then
+              echo "Predicted release tag: \`${{ steps.predict.outputs.release_tag }}\`"
+            else
+              echo 'No release tag was predicted for this run.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/predict-release-tag.yml
+++ b/.github/workflows/predict-release-tag.yml
@@ -33,29 +33,4 @@ jobs:
         id: predict
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          node <<'EOF'
-          const semanticRelease = require('semantic-release');
-          const fs = require('fs');
-
-          (async () => {
-            const result = await semanticRelease(
-              {
-                dryRun: true,
-                ci: false,
-              },
-              {
-                cwd: process.cwd(),
-                env: process.env,
-                stdout: process.stdout,
-                stderr: process.stderr,
-              },
-            );
-
-            const releaseTag = result && result.nextRelease ? result.nextRelease.gitTag : '';
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=${releaseTag}\n`);
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          EOF
+        run: pnpm run semantic-release -- --dry-run

--- a/.github/workflows/predict-release-tag.yml
+++ b/.github/workflows/predict-release-tag.yml
@@ -33,7 +33,7 @@ jobs:
         id: predict
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: pnpm run semantic-release -- --dry-run
+        run: pnpm exec semantic-release --dry-run
 
       - name: Summarise predicted release tag
         if: ${{ always() }}
@@ -41,9 +41,17 @@ jobs:
           {
             echo '## Predict Release Tag'
             echo ''
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Repository | \`${{ github.repository }}\` |"
+            echo "| Event | \`${{ github.event_name }}\` |"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| Actor | \`${{ github.actor }}\` |"
+            echo "| Workflow run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Prediction step | \`${{ steps.predict.outcome }}\` |"
             if [ -n "${{ steps.predict.outputs.release_tag }}" ]; then
-              echo "Predicted release tag: \`${{ steps.predict.outputs.release_tag }}\`"
+              echo "| Predicted release tag | \`${{ steps.predict.outputs.release_tag }}\` |"
             else
-              echo 'No release tag was predicted for this run.'
+              echo '| Predicted release tag | No release tag predicted |'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/predict-release-tag.yml
+++ b/.github/workflows/predict-release-tag.yml
@@ -15,6 +15,9 @@ jobs:
       release_tag: ${{ steps.predict.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -35,6 +38,41 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: pnpm exec semantic-release --dry-run
 
+      - name: Collect release prediction context
+        id: release_context
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            master) channel="latest" ;;
+            alpha) channel="alpha" ;;
+            beta) channel="beta" ;;
+            *) channel="preview" ;;
+          esac
+
+          last_tag="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+
+          if [ -n "$last_tag" ]; then
+            commit_count="$(git rev-list --count "${last_tag}..HEAD")"
+          else
+            commit_count="$(git rev-list --count HEAD)"
+          fi
+
+          if [ "${{ steps.predict.outcome }}" = "success" ] && [ -z "${{ steps.predict.outputs.release_tag }}" ]; then
+            conclusion='no release'
+          elif [ -n "${{ steps.predict.outputs.release_tag }}" ]; then
+            conclusion='release predicted'
+          else
+            conclusion='prediction failed'
+          fi
+
+          {
+            echo "release_channel=${channel}"
+            echo "last_tag=${last_tag}"
+            echo "commit_count_since_last_tag=${commit_count}"
+            echo "prediction_conclusion=${conclusion}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Summarise predicted release tag
         if: ${{ always() }}
         run: |
@@ -48,7 +86,15 @@ jobs:
             echo "| Ref | \`${{ github.ref_name }}\` |"
             echo "| Actor | \`${{ github.actor }}\` |"
             echo "| Workflow run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Release channel | \`${{ steps.release_context.outputs.release_channel }}\` |"
             echo "| Prediction step | \`${{ steps.predict.outcome }}\` |"
+            echo "| Prediction conclusion | \`${{ steps.release_context.outputs.prediction_conclusion }}\` |"
+            if [ -n "${{ steps.release_context.outputs.last_tag }}" ]; then
+              echo "| Last reachable tag | \`${{ steps.release_context.outputs.last_tag }}\` |"
+            else
+              echo '| Last reachable tag | No prior tag found |'
+            fi
+            echo "| Commits since last tag | \`${{ steps.release_context.outputs.commit_count_since_last_tag }}\` |"
             if [ -n "${{ steps.predict.outputs.release_tag }}" ]; then
               echo "| Predicted release tag | \`${{ steps.predict.outputs.release_tag }}\` |"
             else

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -51,6 +51,44 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run semantic-release
 
+      - name: Collect published packages
+        id: published_packages
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const path = require('path');
+
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const releaseTag = process.env.RELEASE_TAG || '';
+          const releaseVersion = releaseTag.replace(/^v/, '');
+          const packagesDir = path.join(process.cwd(), 'packages');
+
+          let markdown = 'No published package list available';
+
+          if (releaseVersion && fs.existsSync(packagesDir)) {
+            const entries = fs.readdirSync(packagesDir, { withFileTypes: true });
+            const published = entries
+              .filter((entry) => entry.isDirectory())
+              .map((entry) => path.join(packagesDir, entry.name, 'package.json'))
+              .filter((pkgPath) => fs.existsSync(pkgPath))
+              .map((pkgPath) => JSON.parse(fs.readFileSync(pkgPath, 'utf8')))
+              .filter((pkg) => !pkg.private && pkg.version === releaseVersion)
+              .map((pkg) => `- [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`);
+
+            if (published.length > 0) {
+              markdown = published.join('\n');
+            } else {
+              markdown = `No public packages matched \`${releaseVersion}\``;
+            }
+          }
+
+          fs.appendFileSync(outputPath, `packages_markdown<<__PACKAGES__\n${markdown}\n__PACKAGES__\n`);
+          EOF
+        env:
+          RELEASE_TAG: ${{ steps.publish.outputs.release_tag }}
+
       - name: Summarise package publish
         if: ${{ always() }}
         run: |
@@ -71,4 +109,8 @@ jobs:
             else
               echo '| Released tag | No release tag produced |'
             fi
+            echo ''
+            echo '### Published Packages'
+            echo ''
+            echo "${{ steps.published_packages.outputs.packages_markdown }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -57,11 +57,18 @@ jobs:
           {
             echo '## Publish Packages'
             echo ''
-            echo "Build artifacts input: \`${{ inputs.build-artifacts-name }}\`"
-            echo "Publish step outcome: \`${{ steps.publish.outcome }}\`"
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Repository | \`${{ github.repository }}\` |"
+            echo "| Event | \`${{ github.event_name }}\` |"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| Workflow run | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Build artifacts input | \`${{ inputs.build-artifacts-name }}\` |"
+            echo "| Publish step | \`${{ steps.publish.outcome }}\` |"
             if [ -n "${{ steps.publish.outputs.release_tag }}" ]; then
-              echo "Released tag: \`${{ steps.publish.outputs.release_tag }}\`"
+              echo "| Released tag | \`${{ steps.publish.outputs.release_tag }}\` |"
+              echo "| Release URL | [${{ steps.publish.outputs.release_tag }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.publish.outputs.release_tag }}) |"
             else
-              echo 'No release tag was produced during publish.'
+              echo '| Released tag | No release tag produced |'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -50,3 +50,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run semantic-release
+
+      - name: Summarise package publish
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Publish Packages'
+            echo ''
+            echo "Build artifacts input: \`${{ inputs.build-artifacts-name }}\`"
+            echo "Publish step outcome: \`${{ steps.publish.outcome }}\`"
+            if [ -n "${{ steps.publish.outputs.release_tag }}" ]; then
+              echo "Released tag: \`${{ steps.publish.outputs.release_tag }}\`"
+            else
+              echo 'No release tag was produced during publish.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -9,12 +9,22 @@ on:
       release_tag:
         required: true
         type: string
+    outputs:
+      pull-request-number:
+        description: 'The created or updated docs pull request number'
+        value: ${{ jobs.sync-docs.outputs.pull-request-number }}
+      pull-request-operation:
+        description: 'The docs pull request operation performed'
+        value: ${{ jobs.sync-docs.outputs.pull-request-operation }}
 
 jobs:
   # Note: Only sync docs when there is a release_tag (semantic-release produced a tag).
   sync-docs:
     runs-on: ubuntu-latest
     if: ${{ inputs.release_tag != '' }}
+    outputs:
+      pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
+      pull-request-operation: ${{ steps.create_pr.outputs.pull-request-operation }}
     concurrency:
       group: docs-update
       cancel-in-progress: true
@@ -25,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history to ensure tagged commits are available
           fetch-tags: true # Ensure tags are fetched as well
+          persist-credentials: false
 
       - name: Checkout Docusaurus repo
         uses: actions/checkout@v6
@@ -33,6 +44,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           ref: main
           path: packages/docusaurus
+          persist-credentials: false
 
       # Install pnpm
       - name: Install pnpm
@@ -77,6 +89,7 @@ jobs:
         run: pnpm exec docusaurus docs:version ${{ inputs.release_tag }}
 
       - name: Create Pull Request
+        id: create_pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -113,7 +113,7 @@ jobs:
             echo "| Ref | \`${{ github.ref_name }}\` |"
             echo "| Release tag | \`${{ inputs.release_tag }}\` |"
             echo "| Docs artifacts input | \`${{ inputs.docs-artifacts-name }}\` |"
-            echo "| Docs branch | \`docs/update-${{ inputs.release_tag }}\` |"
+            echo "| Target docs branch | \`docs/update-${{ inputs.release_tag }}\` |"
             echo "| Target repository | \`ongov/design-system-developer-documentation-site\` |"
             echo "| Create PR step | \`${{ steps.create_pr.outcome }}\` |"
             if [ -n "${{ steps.create_pr.outputs.pull-request-number }}" ]; then
@@ -122,8 +122,8 @@ jobs:
               echo '| Docs PR | No docs PR number returned |'
             fi
             if [ -n "${{ steps.create_pr.outputs.pull-request-operation }}" ]; then
-              echo "| PR operation | \`${{ steps.create_pr.outputs.pull-request-operation }}\` |"
+              echo "| PR result | \`${{ steps.create_pr.outputs.pull-request-operation }}\` |"
             else
-              echo '| PR operation | No docs PR operation reported |'
+              echo '| PR result | No docs PR operation reported |'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -100,3 +100,24 @@ jobs:
             This PR updates the documentation site for version `${{ inputs.release_tag }}`.
           branch: docs/update-${{ inputs.release_tag }}
           labels: docs-update
+
+      - name: Summarise docs sync
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Sync Docs to Docusaurus'
+            echo ''
+            echo "Release tag: \`${{ inputs.release_tag }}\`"
+            echo "Docs artifacts input: \`${{ inputs.docs-artifacts-name }}\`"
+            echo "Create PR step outcome: \`${{ steps.create_pr.outcome }}\`"
+            if [ -n "${{ steps.create_pr.outputs.pull-request-number }}" ]; then
+              echo "Docs PR: #${{ steps.create_pr.outputs.pull-request-number }}"
+            else
+              echo 'No docs PR number was returned.'
+            fi
+            if [ -n "${{ steps.create_pr.outputs.pull-request-operation }}" ]; then
+              echo "PR operation: \`${{ steps.create_pr.outputs.pull-request-operation }}\`"
+            else
+              echo 'No docs PR operation was reported.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -107,17 +107,23 @@ jobs:
           {
             echo '## Sync Docs to Docusaurus'
             echo ''
-            echo "Release tag: \`${{ inputs.release_tag }}\`"
-            echo "Docs artifacts input: \`${{ inputs.docs-artifacts-name }}\`"
-            echo "Create PR step outcome: \`${{ steps.create_pr.outcome }}\`"
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Source repository | \`${{ github.repository }}\` |"
+            echo "| Ref | \`${{ github.ref_name }}\` |"
+            echo "| Release tag | \`${{ inputs.release_tag }}\` |"
+            echo "| Docs artifacts input | \`${{ inputs.docs-artifacts-name }}\` |"
+            echo "| Docs branch | \`docs/update-${{ inputs.release_tag }}\` |"
+            echo "| Target repository | \`ongov/design-system-developer-documentation-site\` |"
+            echo "| Create PR step | \`${{ steps.create_pr.outcome }}\` |"
             if [ -n "${{ steps.create_pr.outputs.pull-request-number }}" ]; then
-              echo "Docs PR: #${{ steps.create_pr.outputs.pull-request-number }}"
+              echo "| Docs PR | [#${{ steps.create_pr.outputs.pull-request-number }}](${{ github.server_url }}/ongov/design-system-developer-documentation-site/pull/${{ steps.create_pr.outputs.pull-request-number }}) |"
             else
-              echo 'No docs PR number was returned.'
+              echo '| Docs PR | No docs PR number returned |'
             fi
             if [ -n "${{ steps.create_pr.outputs.pull-request-operation }}" ]; then
-              echo "PR operation: \`${{ steps.create_pr.outputs.pull-request-operation }}\`"
+              echo "| PR operation | \`${{ steps.create_pr.outputs.pull-request-operation }}\` |"
             else
-              echo 'No docs PR operation was reported.'
+              echo '| PR operation | No docs PR operation reported |'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,6 +15,7 @@
 		[
 			"@semantic-release/exec",
 			{
+				"verifyReleaseCmd": "echo \"release_tag=${nextRelease.gitTag}\" >> $GITHUB_OUTPUT",
 				"successCmd": "echo \"release_tag=${nextRelease.gitTag}\" >> $GITHUB_OUTPUT"
 			}
 		]


### PR DESCRIPTION
## Summary
- expose docs PR outputs from the reusable sync workflow
- disable persisted checkout credentials in the docs sync job
- add a top-level job to enable docs PR auto-merge after package publish succeeds

## Notes
- this keeps the monorepo as the workflow owner while handing final merge control to the docs repo rules
- paired docs repo PR: https://github.com/ongov/design-system-developer-documentation-site/pull/12
