### PR TITLE
DS-2609: publish form lifecycle contracts

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
@@ -159,11 +159,11 @@ This enum defines the possible values for the reason property in the event paylo
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Accordion component supports multiple languages via the `language` prop, which controls the text used in translatable UI elements (e.g., button labels). If no language is explicitly passed, it defaults to English (`'en'`).
+The Ontario Accordion component supports server-side rendering, with a few considerations:
 
-On the client side, the component also listens for global language change events such as `setAppLanguage` and `headerLanguageToggled`, allowing it to update dynamically when used in conjunction with shared application-level language controls (like `<ontario-header>`).
-
-These language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-accordion language="fr"></ontario-accordion>`).
+- **Language prop:** Pass `language` explicitly during SSR. If not provided, the component defaults to English (`'en'`).
+- **Hydrated-only language events:** Global language events such as `setAppLanguage` and `headerLanguageToggled` only fire after hydration.
+- **Framework guidance:** For deterministic SSR output, set `language` directly in markup (for example, `<ontario-accordion language="fr"></ontario-accordion>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-aside/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-aside/readme.md
@@ -176,16 +176,13 @@ This is another example of an aside. This time, the content is passed as a child
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Aside component supports two ways of defining content:
+The Ontario Aside component supports server-side rendering, with a few considerations:
 
-- Via the `content` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `content` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass aside content through the `content` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `content` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the aside content through the `content` prop. Eg:
 
 ```html
 <ontario-aside headingContent="Notice" content="This is the callout content."></ontario-aside>

--- a/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
@@ -117,7 +117,7 @@ Otherwise, a default Back to Top button can be used as follows:
 The Ontario Back to Top component is SSR-compatible and renders static markup during server-side rendering. For full functionality, client-side hydration is required. To ensure consistency:
 
 - **Scroll behavior and visibility toggling** rely on window and scroll position, which are only available in the browser. These features activate after hydration.
-- **Language Prop**: Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired language explicitly as a prop (e.g., `<ontario-back-to-top language="fr"></ontario-back-to-top>`).
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired language explicitly as a prop (e.g., `<ontario-back-to-top language="fr"></ontario-back-to-top>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
@@ -114,10 +114,11 @@ Otherwise, a default Back to Top button can be used as follows:
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Back to Top component is SSR-compatible and renders static markup during server-side rendering. For full functionality, client-side hydration is required. To ensure consistency:
+The Ontario Back to Top component supports server-side rendering, with a few considerations:
 
-- **Scroll behavior and visibility toggling** rely on window and scroll position, which are only available in the browser. These features activate after hydration.
-- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired language explicitly as a prop (e.g., `<ontario-back-to-top language="fr"></ontario-back-to-top>`).
+- **Scroll behaviour and visibility toggling:** These rely on window and scroll position, which are only available in the browser. These features activate after hydration.
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only language events:** Language change events only fire after hydration.
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-badge/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-badge/readme.md
@@ -118,16 +118,13 @@ This is another example of a badge. This time, the content is passed as a child 
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Badge component supports two ways of defining labels:
+The Ontario Badge component supports server-side rendering, with a few considerations:
 
-- Via the `label` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `label` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass badge text through the `label` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `label` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the badge label through the `label` prop.
 
 ```tsx
 <OntarioBadge label="In progress"></OntarioBadge>

--- a/packages/ontario-design-system-component-library/src/components/ontario-blockquote/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-blockquote/readme.md
@@ -150,16 +150,13 @@ This is another example of a long blockquote. The component calculates the lengt
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Blockquote component supports two ways of defining quotes:
+The Ontario Blockquote component supports server-side rendering, with a few considerations:
 
-- Via the `quote` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
+- **Preferred content source:** Pass blockquote text through the `quote` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR and can produce empty quotes.
+- **Framework guidance:** For deterministic SSR output, prefer `quote` over slotted children.
 
-While both approaches work in the browser, only the `quote` prop is reliably rendered during Server-Side Rendering (SSR).
-
-### SSR-safe example
-
-During SSR, fallback content using `host.textContent` is not reliably available, which can result in empty quotes in the rendered output. This is why it is recommended to pass the blockquote quote through the `quote` prop. Eg:
+### SSR-safe example:
 
 ```tsx
 <OntarioBlockquote quote="Courage is resistance to fear, mastery of fear—not absence of fear."></OntarioBlockquote>

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
@@ -333,16 +333,13 @@ It can be confusing and frustrating for users to expect a button to trigger an a
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Button component supports two ways of defining labels:
+The Ontario Button component supports server-side rendering, with a few considerations:
 
-- Via the `label` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
+- **Preferred content source:** Pass button text through the `label` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `label` over slotted children.
 
-While both approaches work in the browser, only the `label` prop is reliably rendered during Server-Side Rendering (SSR).
-
-### SSR-safe Example
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the button content through the `label` prop. Eg:
+### SSR-safe example:
 
 ```html
 <ontario-button label="Click me"></ontario-button>

--- a/packages/ontario-design-system-component-library/src/components/ontario-callout/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-callout/readme.md
@@ -160,16 +160,13 @@ This is another example of an callout. This time, the content is passed as a chi
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Callout component supports two ways of defining content:
+The Ontario Callout component supports server-side rendering, with a few considerations:
 
-- Via the `content` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `content` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass callout content through the `content` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `content` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the callout content through the `content` prop. Eg:
 
 ```tsx
 <OntarioCallout headingContent="Notice" content="This is the callout content."></OntarioCallout>

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
@@ -245,12 +245,11 @@ The `header-colour` property supports a wide range of values, including:
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Card component is SSR-compatible and will render static HTML for the card’s image, heading, and description based on its props.
+The Ontario Card component supports server-side rendering, with a few considerations:
 
-For best SSR results:
-
-- **Always provide the `label` prop** to ensure the heading and link are rendered with visible content. During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the card label through the `label` prop.
-- If `ariaLabelText` is used, consider whether it’s appropriate for both the image and heading links, or whether separate values should be passed (if split becomes available in future versions).
+- **Preferred content source:** Always provide the `label` prop so heading and link text are deterministic in SSR output.
+- **Slotted content caveat:** Fallback content via `host.textContent` is not reliably available during SSR.
+- **Accessibility guidance:** If `ariaLabelText` is used, confirm it is appropriate for both image and heading links.
 
 ### SSR-safe example:
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -391,7 +391,7 @@ expander for checkbox option 2", "content": "Example hint expander content for c
 The Ontario Checkboxes component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** Each checkbox option should use a stable `elementId`. If option IDs are generated differently between server and client, hydration mismatches are more likely.
+- **Dynamic ID generation:** Each checkbox option should use a stable `elementId`. If option IDs are generated differently between server and client, hydration mismatches are more likely.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a checkbox-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
 - **Hydrated-only behaviour:** Group-level error messaging and custom event handling should be treated as hydrated behaviour. Keep the group `name` stable across all options and verify the full submit flow in the consuming application.

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -386,14 +386,18 @@ expander for checkbox option 2", "content": "Example hint expander content for c
 - Do not preselect checkboxes (there should be no checked attribute by default on the checkbox)
 - All checkboxes in a group should have the same name value to associate them as a group of options
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Checkbox component supports Server-Side Rendering (SSR), but to ensure correct rendering and prevent hydration mismatches, keep the following in mind:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Langauge-Props**: Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-checkbox language="fr"></ontario-checkbox>`).
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, you should explicitly pass a stable `elementId`.
-- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Ensure this does not impact critical accessibility paths.
-- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR (before hydration), the component will render as a standard `<input type="checkbox">`, meaning it can still function inside a `<form>` and be submitted normally. However, enhanced form behavior (like validation or custom value handling) only becomes active after hydration in the browser.
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-checkboxes` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped checkbox pattern.                                                                                                                                                                 |
+| Pre-hydration form participation | Treat this component as suitable for native checkbox-group submission when every option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                 |
+| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits group-level change and focus events for client-managed updates.                                                                                                                                           |
+| Validation timing                | Required-state messaging, group-level error messaging, and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                   |
+| No-JS fallback                   | A simple grouped-checkbox submit flow is appropriate when option ids and names are stable, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                                     |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -386,18 +386,16 @@ expander for checkbox option 2", "content": "Example hint expander content for c
 - Do not preselect checkboxes (there should be no checked attribute by default on the checkbox)
 - All checkboxes in a group should have the same name value to associate them as a group of options
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Checkboxes component supports server-side rendering, with a few considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-checkboxes` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped checkbox pattern.                                                                                                                                                                 |
-| Pre-hydration form participation | Treat this component as suitable for native checkbox-group submission when every option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                 |
-| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits group-level change and focus events for client-managed updates.                                                                                                                                           |
-| Validation timing                | Required-state messaging, group-level error messaging, and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                   |
-| No-JS fallback                   | A simple grouped-checkbox submit flow is appropriate when option ids and names are stable, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                                     |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** Each checkbox option should use a stable `elementId`. If option ids are generated differently between server and client, hydration mismatches are more likely.
+- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a checkbox-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
+- **Progressive enhancement:** Keep the group `name` stable across all options and verify the full submit flow in the consuming application, especially if you depend on error messaging or custom event handling.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For client-managed integrations, use the event examples below. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -386,11 +386,11 @@ expander for checkbox option 2", "content": "Example hint expander content for c
 - Do not preselect checkboxes (there should be no checked attribute by default on the checkbox)
 - All checkboxes in a group should have the same name value to associate them as a group of options
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-checkboxes` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped checkbox pattern.                                                                                                                                                                 |
 | Pre-hydration form participation | Treat this component as suitable for native checkbox-group submission when every option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                 |

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -391,10 +391,10 @@ expander for checkbox option 2", "content": "Example hint expander content for c
 The Ontario Checkboxes component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** Each checkbox option should use a stable `elementId`. If option ids are generated differently between server and client, hydration mismatches are more likely.
+- **Stable IDs:** Each checkbox option should use a stable `elementId`. If option IDs are generated differently between server and client, hydration mismatches are more likely.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a checkbox-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
-- **Progressive enhancement:** Keep the group `name` stable across all options and verify the full submit flow in the consuming application, especially if you depend on error messaging or custom event handling.
+- **Hydrated-only behaviour:** Group-level error messaging and custom event handling should be treated as hydrated behaviour. Keep the group `name` stable across all options and verify the full submit flow in the consuming application.
 - **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For client-managed integrations, use the event examples below. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 <!-- Auto Generated Below -->

--- a/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/readme.md
@@ -118,16 +118,13 @@ Alternatively, HTML content can be supplied as the child of the critical alert r
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Critical Alert component supports two ways of defining content:
+The Ontario Critical Alert component supports server-side rendering, with a few considerations:
 
-- Via the `content` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `content` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass alert content through the `content` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `content` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the critical alert content through the `content` prop. Eg:
 
 ```tsx
 <OntarioCriticalAlert content="Emergency alert message."></OntarioCriticalAlert>

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -273,18 +273,22 @@ The `caption` property is used to render the label for the ontario-input. It can
 caption='{ "captionText": "Exact Date", "captionType": "heading" }'
 ```
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Date Input component is compatible with server-side rendering, with a few additional considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                                     |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-date-input` host with caption, hint, and segmented day, month, and year fields. The component can render server-side, but its aggregate value contract is still a hydrated behavior.                                                                                                                                    |
-| Pre-hydration form participation | Do not assume the aggregate ISO date value will participate in native form submission before hydration. If submission before hydration or without JavaScript is required, provide a native fallback pattern in the consuming app.                                                                                                            |
-| Hydrated form participation      | After hydration, the component assembles the segmented inputs into a single ISO 8601 value, participates in form submission through the form-associated custom elements API, and emits both field-level and aggregate host events.                                                                                                           |
-| Validation timing                | Date validation, aggregate value normalization, and synthetic host `input` and `change` events should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                         |
-| No-JS fallback                   | A no-JS submit path is not provided by the component on its own. Use explicit fallback markup if the flow must work before hydration.                                                                                                                                                                                                        |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or progressive-enhancement flows once hydrated. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Rendered structure vs submitted value:** During SSR, the component renders the expected day, month, and year inputs. The aggregated ISO 8601 value is assembled after hydration, so do not assume that aggregate value will participate in native form submission before hydration.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. Full date normalization, aggregate host `input` and `change` events, and component-managed date validation become available after hydration.
+- **No-JavaScript fallback:** If a flow must submit before hydration or without JavaScript, provide explicit native fallback markup in the consuming application.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or progressive-enhancement flows once hydrated. For client-managed integrations, use the event examples below. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
+
+> **Recommended for SSR:**
+>
+> ```tsx
+> <OntarioDateInput elementId="my-date-input" language="en"></OntarioDateInput>
+> ```
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -273,19 +273,18 @@ The `caption` property is used to render the label for the ontario-input. It can
 caption='{ "captionText": "Exact Date", "captionType": "heading" }'
 ```
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Date Input component is compatible with Server-Side Rendering (SSR), but a few guidelines are recommended for best results:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Pass `elementId` explicitly** when using this component with SSR. Otherwise, a randomly generated ID may mismatch during hydration.
-- **Avoid relying on language toggle events** (`setAppLanguage`, `headerLanguageToggled`) to determine language server-side. Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-date-input language="fr"></ontario-date-input>`).
-- **Form Submission Support:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. This requires client-side hydration to fully activate. While the component will render as expected during SSR, native form behavior will only function once hydrated in the browser.
-
-> **Recommended for SSR:**
->
-> ```tsx
-> <OntarioDateInput elementId="my-date-input" language="en"></OntarioDateInput>
-> ```
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-date-input` host with caption, hint, and segmented day, month, and year fields. The component can render server-side, but its aggregate value contract is still a hydrated behavior.                                                                                                                                    |
+| Pre-hydration form participation | Do not assume the aggregate ISO date value will participate in native form submission before hydration. If submission before hydration or without JavaScript is required, provide a native fallback pattern in the consuming app.                                                                                                            |
+| Hydrated form participation      | After hydration, the component assembles the segmented inputs into a single ISO 8601 value, participates in form submission through the form-associated custom elements API, and emits both field-level and aggregate host events.                                                                                                           |
+| Validation timing                | Date validation, aggregate value normalization, and synthetic host `input` and `change` events should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                         |
+| No-JS fallback                   | A no-JS submit path is not provided by the component on its own. Use explicit fallback markup if the flow must work before hydration.                                                                                                                                                                                                        |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or progressive-enhancement flows once hydrated. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -278,7 +278,7 @@ caption='{ "captionText": "Exact Date", "captionType": "heading" }'
 The Ontario Date Input component is compatible with server-side rendering, with a few additional considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Rendered structure vs submitted value:** During SSR, the component renders the expected day, month, and year inputs. The aggregated ISO 8601 value is assembled after hydration, so do not assume that aggregate value will participate in native form submission before hydration.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. Full date normalization, aggregate host `input` and `change` events, and component-managed date validation become available after hydration.
 - **No-JavaScript fallback:** If a flow must submit before hydration or without JavaScript, provide explicit native fallback markup in the consuming application.

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -273,11 +273,11 @@ The `caption` property is used to render the label for the ontario-input. It can
 caption='{ "captionText": "Exact Date", "captionType": "heading" }'
 ```
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                                     |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                                     |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-date-input` host with caption, hint, and segmented day, month, and year fields. The component can render server-side, but its aggregate value contract is still a hydrated behavior.                                                                                                                                    |
 | Pre-hydration form participation | Do not assume the aggregate ISO date value will participate in native form submission before hydration. If submission before hydration or without JavaScript is required, provide a native fallback pattern in the consuming app.                                                                                                            |

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -278,7 +278,7 @@ caption='{ "captionText": "Exact Date", "captionType": "heading" }'
 The Ontario Date Input component is compatible with server-side rendering, with a few additional considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Rendered structure vs submitted value:** During SSR, the component renders the expected day, month, and year inputs. The aggregated ISO 8601 value is assembled after hydration, so do not assume that aggregate value will participate in native form submission before hydration.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. Full date normalization, aggregate host `input` and `change` events, and component-managed date validation become available after hydration.
 - **No-JavaScript fallback:** If a flow must submit before hydration or without JavaScript, provide explicit native fallback markup in the consuming application.

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -431,18 +431,32 @@ options='[ { "value": "netflix", "label": "Netflix" }, { "value": "disney-plus",
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 - Do not add any customized styles to dropdown lists - the browser's default is the most accessible.
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Dropdown List component supports server-side rendering, with a few considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-dropdown-list` host with label, hint, option markup, and empty-start option behavior when configured. The interaction model maps to a standard `<select>` pattern.                                                                                                                                            |
-| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
-| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits its event model for client-managed updates.                                                                                                                                                               |
-| Validation timing                | Required-state messaging and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                                                 |
-| No-JS fallback                   | A simple native select submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                         |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected select structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Required-state messaging and the component's event model become available after hydration.
+- **Client-managed behaviour:** If your application depends on emitted events or hydrated validation behaviour, use the event examples below and verify the full submit flow in the consuming application.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
+
+### SSR-safe example:
+
+```tsx
+<OntarioDropdownList
+	name="province"
+	elementId="province"
+	language="en"
+	caption={{ captionText: 'Select your province', captionType: 'heading' }}
+	options={[
+		{ label: 'Ontario', value: 'on' },
+		{ label: 'Quebec', value: 'qc' },
+	]}
+	isEmptyStartOption="Select a province"
+/>
+```
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -431,30 +431,18 @@ options='[ { "value": "netflix", "label": "Netflix" }, { "value": "disney-plus",
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 - Do not add any customized styles to dropdown lists - the browser's default is the most accessible.
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Dropdown List component supports full server-side rendering, with a few considerations:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Language Prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-dropdown-list language="fr"></ontario-dropdown-list>`).
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, you should explicitly pass a stable `elementId`.
-- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Ensure this does not impact critical accessibility paths.
-- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR (before hydration), the component will render as a standard `<select>`, meaning it can still function inside a `<form>` and be submitted normally. However, enhanced form behavior (like validation or custom value handling) only becomes active after hydration in the browser.
-
-### SSR-safe example:
-
-```tsx
-<OntarioDropdownList
-	name="province"
-	elementId="province"
-	language="en"
-	caption={{ captionText: 'Select your province', captionType: 'heading' }}
-	options={[
-		{ label: 'Ontario', value: 'on' },
-		{ label: 'Quebec', value: 'qc' },
-	]}
-	isEmptyStartOption="Select a province"
-/>
-```
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-dropdown-list` host with label, hint, option markup, and empty-start option behavior when configured. The interaction model maps to a standard `<select>` pattern.                                                                                                                                            |
+| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
+| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits its event model for client-managed updates.                                                                                                                                                               |
+| Validation timing                | Required-state messaging and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                                                 |
+| No-JS fallback                   | A simple native select submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                         |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -436,10 +436,10 @@ options='[ { "value": "netflix", "label": "Netflix" }, { "value": "disney-plus",
 The Ontario Dropdown List component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected select structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Required-state messaging and the component's event model become available after hydration.
-- **Client-managed behaviour:** If your application depends on emitted events or hydrated validation behaviour, use the event examples below and verify the full submit flow in the consuming application.
+- **Hydrated-only behaviour:** If your application depends on emitted events or hydrated validation behaviour, use the event examples below and verify the full submit flow in the consuming application.
 - **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 ### SSR-safe example:

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -436,7 +436,7 @@ options='[ { "value": "netflix", "label": "Netflix" }, { "value": "disney-plus",
 The Ontario Dropdown List component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected select structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Required-state messaging and the component's event model become available after hydration.
 - **Hydrated-only behaviour:** If your application depends on emitted events or hydrated validation behaviour, use the event examples below and verify the full submit flow in the consuming application.

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -431,11 +431,11 @@ options='[ { "value": "netflix", "label": "Netflix" }, { "value": "disney-plus",
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 - Do not add any customized styles to dropdown lists - the browser's default is the most accessible.
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-dropdown-list` host with label, hint, option markup, and empty-start option behavior when configured. The interaction model maps to a standard `<select>` pattern.                                                                                                                                            |
 | Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
@@ -961,11 +961,11 @@ two-column-options='{
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Footer component supports multiple languages via the `language` prop, which controls the text used in translatable UI elements (e.g., links). If no language is explicitly passed, it defaults to English (`'en'`).
+The Ontario Footer component supports server-side rendering, with a few considerations:
 
-On the client side, the component also listens for global language change events such as `setAppLanguage` and `headerLanguageToggled`, allowing it to update dynamically when used in conjunction with shared application-level language controls (like `<ontario-header>`).
-
-These language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-footer language="fr"></ontario-footer`).
+- **Language prop:** Pass `language` explicitly during SSR. If not provided, the component defaults to English (`'en'`).
+- **Hydrated-only language events:** Global language events such as `setAppLanguage` and `headerLanguageToggled` only fire after hydration.
+- **Framework guidance:** For deterministic SSR output, set `language` directly in markup (for example, `<ontario-footer language="fr"></ontario-footer>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/readme.md
@@ -498,15 +498,12 @@ To ensure best practices, it is important to limit the number of navigation link
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Header component is partially SSR-compatible. It supports static HTML rendering on the server but defers most dynamic behavior to the browser after hydration.
+The Ontario Header component supports server-side rendering, with a few important limitations:
 
-Important considerations:
-
-- **Dynamic menu fetching via the Ontario Header API (`fetchOntarioMenu`) is browser-only**. This will not execute during SSR, and no menu will be rendered until hydration.
-- **Language detection** (`document.documentElement.lang`, `window`, etc.) is also only available after hydration. Default language will be used until hydration completes. To ensure the correct language is rendered during SSR, explicitly pass the language prop.
-- Internal state updates (like `menuToggle`, `searchToggle`) are interactive and require JavaScript. These elements will not function without hydration.
-- If your framework allows, consider using `client:only` or `useEffect` (React) to delay rendering this component until after hydration in SSR-critical apps.
-- **Use static `menuItems` for SSR environments** and enable the dynamic menu only when client-side rendering is guaranteed.
+- **Hydrated-only menu fetching:** Dynamic menu fetching through `fetchOntarioMenu` is browser-only and will not execute during SSR.
+- **Language prop:** Pass `language` explicitly during SSR. Runtime language detection via `document.documentElement.lang` and `window` is hydrated-only.
+- **Hydrated-only interactions:** Interactive state such as `menuToggle` and `searchToggle` requires JavaScript and is unavailable before hydration.
+- **Framework guidance:** For SSR-critical applications, prefer static `menuItems` and only enable dynamic menu fetching in guaranteed client-side contexts.
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/readme.md
@@ -145,16 +145,13 @@ Since the hint expander information comes after the form element, add text in th
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Hint Expander component supports two ways of defining content:
+The Ontario Hint Expander component supports server-side rendering, with a few considerations:
 
-- Via the `content` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `content` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass hint expander content through the `content` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `content` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the hint expander content through the `content` prop. Eg:
 
 ```tsx
 <OntarioHintExpander hint="What is this?" content="Here is the expanded explanation."></OntarioHintExpander>

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-text/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-text/readme.md
@@ -118,18 +118,15 @@ Example of a hint text that includes the `hint` property, which will override th
   </OntarioHintText>
 </div>
 
-## Technical Note: Content Rendering and SSR (Server-Side Rendering)
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Hint component supports two ways of defining hints:
+The Ontario Hint Text component supports server-side rendering, with a few considerations:
 
-- Via the `hint` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `hint` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass hint content through the `hint` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `hint` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the hint through the `hint` prop. Eg:
 
 ```tsx
 <OntarioHintText hint="Provide a detailed street address."></OntarioHintText>

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -364,11 +364,11 @@ An `element-id` attribute is necessary to allow the input to be associated with 
 
 A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-input` host with label, hint, and error-message structure. The interaction model maps to a standard text input pattern.                                                                                                                                                                                       |
 | Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -364,18 +364,22 @@ An `element-id` attribute is necessary to allow the input to be associated with 
 
 A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Input component supports server-side rendering, with a few considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-input` host with label, hint, and error-message structure. The interaction model maps to a standard text input pattern.                                                                                                                                                                                       |
-| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
-| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and exposes its event model for client-managed updates.                                                                                                                                                             |
-| Validation timing                | Required-state messaging, custom validator logic, and synthetic event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                               |
-| No-JS fallback                   | A simple native submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected text-input structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
+- **Client-managed behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
+
+### SSR-safe example:
+
+```tsx
+<OntarioInput name="firstName" language="en" elementId="first-name"></OntarioInput>
+```
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -369,7 +369,7 @@ A `name` attribute needs to be set to be submitted to the server when the form i
 The Ontario Input component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected text-input structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
 - **Hydrated-only behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -364,20 +364,18 @@ An `element-id` attribute is necessary to allow the input to be associated with 
 
 A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Input component supports server-side rendering, with a few considerations:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Language Prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-input language="fr"></ontario-input>`).
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, you should explicitly pass a stable `elementId`.
-- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Ensure this does not impact critical accessibility paths.
-- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR (before hydration), the component will render as a standard `<input>`, meaning it can still function inside a `<form>` and be submitted normally. However, enhanced form behavior (like validation or custom value handling) only becomes active after hydration in the browser.
-
-### SSR-safe example:
-
-```tsx
-<OntarioInput name="firstName" language="en" elementId="first-name"></OntarioInput>
-```
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-input` host with label, hint, and error-message structure. The interaction model maps to a standard text input pattern.                                                                                                                                                                                       |
+| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
+| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and exposes its event model for client-managed updates.                                                                                                                                                             |
+| Validation timing                | Required-state messaging, custom validator logic, and synthetic event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                               |
+| No-JS fallback                   | A simple native submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -369,10 +369,10 @@ A `name` attribute needs to be set to be submitted to the server when the form i
 The Ontario Input component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected text-input structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
-- **Client-managed behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
+- **Hydrated-only behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
 - **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 ### SSR-safe example:

--- a/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/readme.md
@@ -8,9 +8,11 @@ It is used in the ontario-header component.
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Language toggle component reads the `<html lang="">` attribute and uses `MutationObserver` to track changes to it. However, since DOM access is not available during SSR, this logic only executes in the browser after hydration.
+The Ontario Language Toggle component supports server-side rendering, with a few considerations:
 
-To ensure the correct language is rendered during SSR, explicitly pass the language prop, e.g.: `<ontario-language-toggle language="fr"></ontario-language-toggle>`. This avoids reliance on the `<html>` element, which is inaccessible server-side. It also ensures that other components listening for the `setAppLanguage` event receive the correct value immediately upon hydration.
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only DOM behaviour:** `<html lang="">` detection and `MutationObserver` logic rely on DOM APIs and only execute after hydration.
+- **Framework guidance:** Passing `language` directly avoids server-side dependence on `<html>` and ensures listeners for `setAppLanguage` have the expected value on hydration.
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/readme.md
@@ -141,9 +141,11 @@ There is also a custom message passed to display as the loading content.
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Loading Indicator component is compatible with Server-Side Rendering (SSR), but a few guidelines are recommended for best results:
+The Ontario Loading Indicator component supports server-side rendering, with a few considerations:
 
-- **Avoid relying on language toggle events** (`setAppLanguage`, `headerLanguageToggled`) to determine language server-side. Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-loading-indicator language="fr"></ontario-loading-indicator>`).
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only language events:** Avoid relying on `setAppLanguage` or `headerLanguageToggled` for server-rendered output, because these events only fire after hydration.
+- **Framework guidance:** For deterministic SSR output, set `language` directly in markup (for example, `<ontario-loading-indicator language="fr"></ontario-loading-indicator>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
@@ -142,16 +142,13 @@ Example of success page alert type, where the content is passed as a string rath
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Page Alert component supports two ways of defining content:
+The Ontario Page Alert component supports server-side rendering, with a few considerations:
 
-- Via the `content` prop (as a string)
-- Via slotted children placed between the component's opening and closing tags
-
-While both approaches work in the browser, only the `content` prop is reliably rendered during Server-Side Rendering (SSR).
+- **Preferred content source:** Pass page alert content through the `content` prop.
+- **Slotted content caveat:** Slotted children rely on fallback `host.textContent`, which is not reliably available during SSR.
+- **Framework guidance:** For deterministic SSR output, prefer `content` over slotted children.
 
 ### SSR-safe example:
-
-During SSR, fallback content using `host.textContent` is not reliably available. This is why it is recommended to pass the page alert content through the `content` prop, when possible. Eg:
 
 ```tsx
 <OntarioPageAlert type="error" heading="Submission failed" content="Please try again."></OntarioPageAlert>

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -410,13 +410,18 @@ visible when the hint expander title (hint) is toggled" }'
 
 - Do not pre-select radio buttons (there should be no checked attribute by default on the radio button)
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Radio Button component supports server-side rendering, with a few considerations:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Language Prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-radio-buttons language="fr"></ontario-radio-buttons>`).
-- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Ensure this does not impact critical accessibility paths.
-- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR (before hydration), the component will render as a standard `<input type="radio">`, meaning it can still function inside a `<form>` and be submitted normally. However, enhanced form behavior (like validation or custom value handling) only becomes active after hydration in the browser.
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-radio-buttons` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped radio-button pattern.                                                                                                                                                          |
+| Pre-hydration form participation | Treat this component as suitable for native radio-group submission when each option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                     |
+| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits group-level change and focus events for client-managed updates.                                                                                                                                           |
+| Validation timing                | Required-state messaging, group-level error messaging, and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                   |
+| No-JS fallback                   | A simple grouped-radio submit flow is appropriate when option ids and names are stable, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                                        |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -410,11 +410,11 @@ visible when the hint expander title (hint) is toggled" }'
 
 - Do not pre-select radio buttons (there should be no checked attribute by default on the radio button)
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-radio-buttons` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped radio-button pattern.                                                                                                                                                          |
 | Pre-hydration form participation | Treat this component as suitable for native radio-group submission when each option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -415,7 +415,7 @@ visible when the hint expander title (hint) is toggled" }'
 The Ontario Radio Buttons component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** Each radio option should use a stable `elementId` so the server-rendered markup and hydrated markup stay aligned.
+- **Dynamic ID generation:** Each radio option should use a stable `elementId` so the server-rendered markup and hydrated markup stay aligned.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a radio-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
 - **Hydrated-only behaviour:** Group-level error messaging, hydrated validation, and custom event handling should be treated as hydrated behaviour. Keep the group `name` stable and verify the full submit flow in the consuming application.

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -415,10 +415,10 @@ visible when the hint expander title (hint) is toggled" }'
 The Ontario Radio Buttons component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** Each radio option should use a stable `elementId` so the server-rendered markup and hydrated markup stay aligned.
+- **Stable IDs:** Each radio option should use a stable `elementId` so the server-rendered markup and hydrated markup stay aligned.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a radio-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
-- **Progressive enhancement:** Keep the group `name` stable and verify the full submit flow in the consuming application if you depend on hydrated validation or custom event handling.
+- **Hydrated-only behaviour:** Group-level error messaging, hydrated validation, and custom event handling should be treated as hydrated behaviour. Keep the group `name` stable and verify the full submit flow in the consuming application.
 - **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For client-managed integrations, use the event examples below. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 <!-- Auto Generated Below -->

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -410,18 +410,16 @@ visible when the hint expander title (hint) is toggled" }'
 
 - Do not pre-select radio buttons (there should be no checked attribute by default on the radio button)
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Radio Buttons component supports server-side rendering, with a few considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-radio-buttons` host with a fieldset, legend, option labels, and optional hint content. The interaction model maps to a grouped radio-button pattern.                                                                                                                                                          |
-| Pre-hydration form participation | Treat this component as suitable for native radio-group submission when each option has a stable `elementId` and the group has a stable `name` and `language`. Do not rely on runtime language-toggle events before hydration.                                                                                                     |
-| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and emits group-level change and focus events for client-managed updates.                                                                                                                                           |
-| Validation timing                | Required-state messaging, group-level error messaging, and synthetic change-event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                   |
-| No-JS fallback                   | A simple grouped-radio submit flow is appropriate when option ids and names are stable, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                                        |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** Each radio option should use a stable `elementId` so the server-rendered markup and hydrated markup stay aligned.
+- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders a radio-group structure that can support straightforward form submission when the group `name`, `language`, and option ids are stable. Group-level error messaging and emitted events become available after hydration.
+- **Progressive enhancement:** Keep the group `name` stable and verify the full submit flow in the consuming application if you depend on hydrated validation or custom event handling.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For client-managed integrations, use the event examples below. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
@@ -125,9 +125,11 @@ caption='{ "captionText": "Input label", "captionType": "large" }'
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Search Box component is compatible with Server-Side Rendering (SSR), but a few guidelines are recommended for best results:
+The Ontario Search Box component supports server-side rendering, with a few considerations:
 
-- **Avoid relying on language toggle events** (`setAppLanguage`, `headerLanguageToggled`) to determine language server-side. Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-search-box language="fr"></ontario-search-box>`).
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only language events:** Avoid relying on `setAppLanguage` or `headerLanguageToggled` for server-rendered output, because these events only fire after hydration.
+- **Framework guidance:** For deterministic SSR output, set `language` directly in markup (for example, `<ontario-search-box language="fr"></ontario-search-box>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/readme.md
@@ -403,9 +403,11 @@ handleBackButton(event: Event): void {
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Step Indicator component is compatible with Server-Side Rendering (SSR), but a few guidelines are recommended for best results:
+The Ontario Step Indicator component supports server-side rendering, with a few considerations:
 
-- **Avoid relying on language toggle events** (`setAppLanguage`, `headerLanguageToggled`) to determine language server-side. Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-step-indicator language="fr"></ontario-step-indicator>`).
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only language events:** Avoid relying on `setAppLanguage` or `headerLanguageToggled` for server-rendered output, because these events only fire after hydration.
+- **Framework guidance:** For deterministic SSR output, set `language` directly in markup (for example, `<ontario-step-indicator language="fr"></ontario-step-indicator>`).
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/readme.md
@@ -668,16 +668,11 @@ Used to define the table body data. Note that the keys passed to the `data` obje
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Table component is generally safe for server-side rendering (SSR) when used with valid, static data.
+The Ontario Table component supports server-side rendering, with a few considerations:
 
-However, **it's important to note** that the component dynamically calculates and applies a top scrollbar based on the rendered width of the table. Because this calculation depends on browser-specific layout measurements, the scrollbar will not be visible during SSR. It will appear after hydration, once the component finishes rendering in the client.
-
-### Best Practices
-
-Props such as `tableColumns` and `tableData` are parsed from JSON. To avoid hydration mismatch:
-
-- Pass structured arrays directly instead of JSON strings when using JSX.
-- Ensure any JSON strings are valid and match the server-rendered data exactly.
+- **Hydrated-only layout behaviour:** The top scrollbar is calculated from rendered layout width, so it appears after hydration and is not visible in SSR HTML.
+- **Data consistency:** `tableColumns` and `tableData` are JSON-parsed. Keep server and client values identical to avoid hydration mismatch.
+- **Framework guidance:** In JSX, prefer structured arrays over JSON strings when possible.
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
@@ -131,10 +131,10 @@ Example of a task-list component with tasks inside.
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Task List component is SSR-compatible but includes some client-only behavior.
+The Ontario Task List component supports server-side rendering, with a few considerations:
 
-- To avoid hydration mismatch, **always pass a valid `headingLevel` prop**. Acceptable values: `"h1"`, `"h2"`, `"h3"`, `"h4"`. An invalid value will be replaced with `"h2"` on the client.
-- **Task counts are calculated after hydration and are not rendered during SSR**. If you require stable output for task totals in SSR, consider rendering them statically with props.
+- **Heading level validation:** Always pass a valid `headingLevel` (`"h1"`–`"h4"`). Invalid values are replaced with `"h2"` on the client.
+- **Hydrated-only behaviour:** Task counts are calculated after hydration and are not rendered during SSR.
 
 ### SSR-safe example:
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
@@ -144,10 +144,11 @@ Example of a task with a hint.
 
 ## Technical Note: SSR (Server-Side Rendering) Considerations
 
-The Ontario Task component is SSR-compatible and renders predictably during hydration. For full consistency:
+The Ontario Task component supports server-side rendering, with a few considerations:
 
-- **Always pass a valid `taskStatus` prop**. Invalid values will default to 'NotStarted' at runtime.
-- **Language Prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-task language="fr"></ontario-task>`).
+- **Task status validation:** Always pass a valid `taskStatus`. Invalid values default to `'NotStarted'` at runtime.
+- **Language prop:** Pass `language` explicitly during SSR.
+- **Hydrated-only language events:** Language change events only fire after hydration.
 
 ### SSR-safe example:
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -212,11 +212,11 @@ hintExpander='{ "hint": "This is the hint expander title", "content": "This is t
 - An `element-id` attribute is necessary to allow the textarea to be associated with a label element
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Lifecycle contract
+## Technical Note: SSR (Server-Side Rendering) and form behaviour
 
-Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
+If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
 
-| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Server-rendered shape            | Renders the `ontario-textarea` host with label, hint, and error-message structure. The interaction model maps to a standard `<textarea>` pattern.                                                                                                                                                                                  |
 | Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -217,7 +217,7 @@ hintExpander='{ "hint": "This is the hint expander title", "content": "This is t
 The Ontario Textarea component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected `<textarea>` structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
 - **Hydrated-only behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -212,20 +212,18 @@ hintExpander='{ "hint": "This is the hint expander title", "content": "This is t
 - An `element-id` attribute is necessary to allow the textarea to be associated with a label element
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Technical Note: SSR (Server-Side Rendering) Considerations
+## Lifecycle contract
 
-The Ontario Textarea component supports server-side rendering, with a few considerations:
+Use the same lifecycle contract structure for form-component docs so teams can compare SSR, hydration, and fallback behavior quickly.
 
-- **Language Prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, it's recommended to pass the desired `language` explicitly as a prop (e.g., `<ontario-textarea language="fr"></ontario-textarea>`).
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, you should explicitly pass a stable `elementId`.
-- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Ensure this does not impact critical accessibility paths.
-- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR (before hydration), the component will render as a standard `<textarea>`, meaning it can still function inside a `<form>` and be submitted normally. However, enhanced form behavior (like validation or custom value handling) only becomes active after hydration in the browser.
-
-### SSR-safe example:
-
-```tsx
-<OntarioTextarea name="comments" language="en" elementId="comments"></OntarioTextarea>
-```
+| Lifecycle state                  | Contract                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server-rendered shape            | Renders the `ontario-textarea` host with label, hint, and error-message structure. The interaction model maps to a standard `<textarea>` pattern.                                                                                                                                                                                  |
+| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
+| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and exposes its event model for client-managed updates.                                                                                                                                                             |
+| Validation timing                | Required-state messaging, custom validator logic, and synthetic event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                               |
+| No-JS fallback                   | A simple native submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                |
+| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
 
 <!-- Auto Generated Below -->
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -217,10 +217,10 @@ hintExpander='{ "hint": "This is the hint expander title", "content": "This is t
 The Ontario Textarea component supports server-side rendering, with a few considerations:
 
 - **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
-- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Stable IDs:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
 - **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
 - **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected `<textarea>` structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
-- **Client-managed behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
+- **Hydrated-only behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
 - **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
 ### SSR-safe example:

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -212,18 +212,22 @@ hintExpander='{ "hint": "This is the hint expander title", "content": "This is t
 - An `element-id` attribute is necessary to allow the textarea to be associated with a label element
 - A `name` attribute needs to be set to be submitted to the server when the form is submitted.
 
-## Technical Note: SSR (Server-Side Rendering) and form behaviour
+## Technical Note: SSR (Server-Side Rendering) Considerations
 
-If you are rendering this component on the server, use the notes below to understand what works before hydration, what becomes available after hydration, and what to verify in no-JavaScript or progressively enhanced form flows.
+The Ontario Textarea component supports server-side rendering, with a few considerations:
 
-| What to check                    | Guidance                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server-rendered shape            | Renders the `ontario-textarea` host with label, hint, and error-message structure. The interaction model maps to a standard `<textarea>` pattern.                                                                                                                                                                                  |
-| Pre-hydration form participation | Treat this component as suitable for native form submission when `name`, `language`, and a stable `elementId` are provided. Do not rely on runtime language-toggle events before hydration.                                                                                                                                        |
-| Hydrated form participation      | After hydration, the component participates in form submission through the form-associated custom elements API and exposes its event model for client-managed updates.                                                                                                                                                             |
-| Validation timing                | Required-state messaging, custom validator logic, and synthetic event behavior should be treated as hydrated behavior. Keep server-side validation authoritative for submitted data.                                                                                                                                               |
-| No-JS fallback                   | A simple native submit flow is appropriate when the component is rendered with a stable `name` and `elementId`, but progressive-enhancement behavior should still be verified in the consuming app.                                                                                                                                |
-| Framework notes                  | Use the HTML `<form>` example above for native submit or Next.js server-action style flows. Use the event-model examples below for client-managed flows after hydration. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/). |
+- **Language prop:** Language change events only fire in the browser after hydration. To ensure the correct language is rendered during SSR, pass the desired `language` explicitly as a prop.
+- **Dynamic ID generation:** If `elementId` is not passed, a UUID is generated at runtime. To prevent hydration mismatches between server and client, explicitly pass a stable `elementId`.
+- **Hint text and accessibility IDs:** If using `ontario-hint-text`, note that the `aria-describedby` reference is resolved after hydration. Make sure this does not impact critical accessibility paths in your application.
+- **Form participation:** This component uses the [Form-Associated Custom Elements](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) API (`@AttachInternals`) to participate in native form submission. During SSR, it renders with the expected `<textarea>` structure and can support straightforward form submission when `name`, `language`, and `elementId` are stable. Enhanced validation, custom validators, and the component's event model become available after hydration.
+- **Client-managed behaviour:** If your application depends on custom events or runtime validation, use the event examples below and treat that behaviour as hydrated-only.
+- **Framework guidance:** Use the HTML `<form>` example above for native submit or Next.js server-action style flows. For App Router setup details, follow the [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
+
+### SSR-safe example:
+
+```tsx
+<OntarioTextarea name="comments" language="en" elementId="comments"></OntarioTextarea>
+```
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
## Summary
- add a shared lifecycle contract section to the six priority form component readmes
- replace older SSR-only note blocks with consistent guidance for pre-hydration, hydrated, and no-JS behaviour
- point readers to existing form and event examples plus the shared Next.js App Router guide for implementation patterns

## Components covered
- `ontario-input`
- `ontario-textarea`
- `ontario-date-input`
- `ontario-checkboxes`
- `ontario-radio-buttons`
- `ontario-dropdown-list`

## Notes for review
- `ontario-date-input` is documented more conservatively because its aggregate ISO value contract depends on hydration
- grouped controls call out stable option ids, stable group names, and verification in consuming apps
- this PR is documentation-focused and does not change component runtime behaviour

## Testing
- not run; documentation-only changes
