### PR TITLE
DS-2611: add top-level component JSDoc links to component guidance

### DIFF
--- a/packages/ontario-design-system-component-library/src/components.d.ts
+++ b/packages/ontario-design-system-component-library/src/components.d.ts
@@ -135,6 +135,13 @@ export namespace Components {
 		 */
 		name: string;
 	}
+	/**
+	 * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+	 */
 	interface OntarioAside {
 		/**
 		 * Optional text to be displayed as the content for the aside component. If a string is passed, it will automatically be nested in a paragraph tag.  HTML content can also be passed as the child/children of the aside component if additional/different elements for the content are needed.
@@ -234,6 +241,13 @@ export namespace Components {
 		 */
 		type: ButtonType;
 	}
+	/**
+	 * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+	 */
 	interface OntarioCallout {
 		/**
 		 * Optional text to be displayed as the content for the callout component. If a string is passed, it will automatically be nested in a paragraph tag.  HTML content can also be passed as the child/children of the callout component if additional/different elements for the content are needed.
@@ -2793,6 +2807,13 @@ export namespace Components {
 		 */
 		type: 'small' | 'large';
 	}
+	/**
+	 * Ontario Page Alert is used for high-importance status messages that apply to the whole page
+	 * (for example informational, warning, success, or error outcomes).
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 */
 	interface OntarioPageAlert {
 		/**
 		 * The main content for the page alert. This can be rendered as either string or HTML content.
@@ -3192,6 +3213,13 @@ declare global {
 		prototype: HTMLOntarioAccordionElement;
 		new (): HTMLOntarioAccordionElement;
 	};
+	/**
+	 * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+	 */
 	interface HTMLOntarioAsideElement extends Components.OntarioAside, HTMLStencilElement {}
 	var HTMLOntarioAsideElement: {
 		prototype: HTMLOntarioAsideElement;
@@ -3217,6 +3245,13 @@ declare global {
 		prototype: HTMLOntarioButtonElement;
 		new (): HTMLOntarioButtonElement;
 	};
+	/**
+	 * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+	 */
 	interface HTMLOntarioCalloutElement extends Components.OntarioCallout, HTMLStencilElement {}
 	var HTMLOntarioCalloutElement: {
 		prototype: HTMLOntarioCalloutElement;
@@ -4407,6 +4442,13 @@ declare global {
 		prototype: HTMLOntarioLoadingIndicatorElement;
 		new (): HTMLOntarioLoadingIndicatorElement;
 	};
+	/**
+	 * Ontario Page Alert is used for high-importance status messages that apply to the whole page
+	 * (for example informational, warning, success, or error outcomes).
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 */
 	interface HTMLOntarioPageAlertElement extends Components.OntarioPageAlert, HTMLStencilElement {}
 	var HTMLOntarioPageAlertElement: {
 		prototype: HTMLOntarioPageAlertElement;
@@ -4788,6 +4830,13 @@ declare namespace LocalJSX {
 		 */
 		onAccordionChange?: (event: OntarioAccordionCustomEvent<AccordionChangeDetail>) => void;
 	}
+	/**
+	 * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+	 */
 	interface OntarioAside {
 		/**
 		 * Optional text to be displayed as the content for the aside component. If a string is passed, it will automatically be nested in a paragraph tag.  HTML content can also be passed as the child/children of the aside component if additional/different elements for the content are needed.
@@ -4887,6 +4936,13 @@ declare namespace LocalJSX {
 		 */
 		type?: ButtonType;
 	}
+	/**
+	 * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+	 */
 	interface OntarioCallout {
 		/**
 		 * Optional text to be displayed as the content for the callout component. If a string is passed, it will automatically be nested in a paragraph tag.  HTML content can also be passed as the child/children of the callout component if additional/different elements for the content are needed.
@@ -7571,6 +7627,13 @@ declare namespace LocalJSX {
 		 */
 		type?: 'small' | 'large';
 	}
+	/**
+	 * Ontario Page Alert is used for high-importance status messages that apply to the whole page
+	 * (for example informational, warning, success, or error outcomes).
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 */
 	interface OntarioPageAlert {
 		/**
 		 * The main content for the page alert. This can be rendered as either string or HTML content.
@@ -8077,11 +8140,25 @@ declare module '@stencil/core' {
 	export namespace JSX {
 		interface IntrinsicElements {
 			'ontario-accordion': LocalJSX.OntarioAccordion & JSXBase.HTMLAttributes<HTMLOntarioAccordionElement>;
+			/**
+			 * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+			 * For component selection guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+			 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+			 */
 			'ontario-aside': LocalJSX.OntarioAside & JSXBase.HTMLAttributes<HTMLOntarioAsideElement>;
 			'ontario-back-to-top': LocalJSX.OntarioBackToTop & JSXBase.HTMLAttributes<HTMLOntarioBackToTopElement>;
 			'ontario-badge': LocalJSX.OntarioBadge & JSXBase.HTMLAttributes<HTMLOntarioBadgeElement>;
 			'ontario-blockquote': LocalJSX.OntarioBlockquote & JSXBase.HTMLAttributes<HTMLOntarioBlockquoteElement>;
 			'ontario-button': LocalJSX.OntarioButton & JSXBase.HTMLAttributes<HTMLOntarioButtonElement>;
+			/**
+			 * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+			 * For component selection guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+			 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+			 */
 			'ontario-callout': LocalJSX.OntarioCallout & JSXBase.HTMLAttributes<HTMLOntarioCalloutElement>;
 			'ontario-card': LocalJSX.OntarioCard & JSXBase.HTMLAttributes<HTMLOntarioCardElement>;
 			'ontario-card-collection': LocalJSX.OntarioCardCollection &
@@ -8315,6 +8392,13 @@ declare module '@stencil/core' {
 				JSXBase.HTMLAttributes<HTMLOntarioLanguageToggleElement>;
 			'ontario-loading-indicator': LocalJSX.OntarioLoadingIndicator &
 				JSXBase.HTMLAttributes<HTMLOntarioLoadingIndicatorElement>;
+			/**
+			 * Ontario Page Alert is used for high-importance status messages that apply to the whole page
+			 * (for example informational, warning, success, or error outcomes).
+			 * For component selection guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+			 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+			 */
 			'ontario-page-alert': LocalJSX.OntarioPageAlert & JSXBase.HTMLAttributes<HTMLOntarioPageAlertElement>;
 			'ontario-radio-buttons': LocalJSX.OntarioRadioButtons & JSXBase.HTMLAttributes<HTMLOntarioRadioButtonsElement>;
 			'ontario-search-box': LocalJSX.OntarioSearchBox & JSXBase.HTMLAttributes<HTMLOntarioSearchBoxElement>;

--- a/packages/ontario-design-system-component-library/src/components.d.ts
+++ b/packages/ontario-design-system-component-library/src/components.d.ts
@@ -114,6 +114,12 @@ export { TaskStatuses } from './utils/common/task-statuses.enum';
 export { TaskHeadingLevel } from './components/ontario-task/ontario-task';
 export { TaskListHeadingLevel } from './components/ontario-task-list/ontario-task-list';
 export namespace Components {
+	/**
+	 * Ontario Accordion presents collapsible sections of content.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/accordions.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+	 */
 	interface OntarioAccordion {
 		/**
 		 * Used to include individual accordion data for the accordion component. Accepts an array of Accordion (@see Accordion) items or a JSON string of that array.  The `content` is rendered either as plain text or HTML depending on `accordionContentType`.
@@ -167,12 +173,24 @@ export namespace Components {
 		 */
 		highlightColour?: HighlightColourOptions;
 	}
+	/**
+	 * Ontario Back to Top helps users quickly return to the top of long pages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/back-to-top.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+	 */
 	interface OntarioBackToTop {
 		/**
 		 * The language of the component. This is used for translations, and is by default set through event listeners checking for a language property from the header. If no language prop is passed, it will default to English.
 		 */
 		language?: Language;
 	}
+	/**
+	 * Ontario Badge displays concise status labels and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/badges.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+	 */
 	interface OntarioBadge {
 		/**
 		 * An aria label for screen readers.  Used to provide more context to screen readers if necessary.  This property is optional.
@@ -189,6 +207,12 @@ export namespace Components {
 		 */
 		label: string;
 	}
+	/**
+	 * Ontario Blockquote displays quoted content with optional attribution.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/blockquote.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+	 */
 	interface OntarioBlockquote {
 		/**
 		 * Optional text to be displayed as the attribution (the author) of the quote.
@@ -203,6 +227,12 @@ export namespace Components {
 		 */
 		quote: string;
 	}
+	/**
+	 * Ontario Button triggers actions and supports button or link behavior.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 */
 	interface OntarioButton {
 		/**
 		 * Provides more context as to what the button interaction is doing. This should only be used for accessibility purposes, if the button interaction requires more description than what the text provides.   This is optional.
@@ -273,6 +303,12 @@ export namespace Components {
 		 */
 		highlightColour?: HighlightColourOptions;
 	}
+	/**
+	 * Ontario Card displays linked content summaries with optional media and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/cards.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+	 */
 	interface OntarioCard {
 		/**
 		 * Provides more context as to what the card interaction is doing. This should only be used for accessibility purposes, if the card interaction requires more * * description than what the text provides.  This is optional.
@@ -328,6 +364,11 @@ export namespace Components {
 		 */
 		layoutDirection?: LayoutDirection;
 	}
+	/**
+	 * Ontario Card Collection lays out multiple cards in a responsive grid.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+	 */
 	interface OntarioCardCollection {
 		/**
 		 * The number of cards to display per row.  If no number is passed, it will default to 3.
@@ -335,6 +376,12 @@ export namespace Components {
 		 */
 		cardsPerRow: CardsPerRow;
 	}
+	/**
+	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 */
 	interface OntarioCheckboxes {
 		/**
 		 * The text to display for the checkbox legend.
@@ -385,6 +432,12 @@ export namespace Components {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Critical Alert communicates urgent, high-priority emergency information.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/critical-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+	 */
 	interface OntarioCriticalAlert {
 		/**
 		 * Content for critical alert message. It can be either string or HTML content. The content is already wrapped in a paragraph tag, so if using HTML content, the paragraph tag can be ommitted.
@@ -392,6 +445,12 @@ export namespace Components {
 		 */
 		content: string | HTMLElement;
 	}
+	/**
+	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dates.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 */
 	interface OntarioDateInput {
 		/**
 		 * The text to display as the input label
@@ -437,6 +496,12 @@ export namespace Components {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 */
 	interface OntarioDropdownList {
 		/**
 		 * The text to display for the dropdown list label.
@@ -497,6 +562,12 @@ export namespace Components {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Fieldset groups related form controls under a shared legend.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/fieldsets.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+	 */
 	interface OntarioFieldset {
 		/**
 		 * The text value used for the legend of the fieldset.
@@ -508,6 +579,13 @@ export namespace Components {
 		 */
 		legendSize: CaptionType;
 	}
+	/**
+	 * Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/simple-footer.html
+	 * - https://designsystem.ontario.ca/components/detail/expanded-footer.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+	 */
 	interface OntarioFooter {
 		/**
 		 * The base path to an assets folder containing the Design System assets
@@ -544,6 +622,11 @@ export namespace Components {
 		 */
 		type: OntarioFooterType;
 	}
+	/**
+	 * Ontario Form Container applies consistent spacing between grouped form elements.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+	 */
 	interface OntarioFormContainer {
 		/**
 		 * Defines the gap (bottom margin) between slotted form elements. If no gap prop is provided, it will default to 'default'.
@@ -551,6 +634,14 @@ export namespace Components {
 		 */
 		gap: 'default' | 'condensed';
 	}
+	/**
+	 * Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+	 */
 	interface OntarioHeader {
 		/**
 		 * Information pertaining to the application and ServiceOntario headers.  For the 'application' header type, this includes the application name, URL and optional props for the number of links in the subheader for desktop, tablet, and mobile views.  For the 'serviceOntario' header type, the 'title' property is used as the service name displayed in the subheader.
@@ -600,10 +691,14 @@ export namespace Components {
 		type?: OntarioHeaderType;
 	}
 	/**
-	 * Ontario Header Menu Tabs Component
-	 * Provides a tabbed navigation interface for mobile/tablet views.
-	 * Displays two tabs (Topics and Sign In) with overflow menu content.
-	 * Manages keyboard navigation, focus trapping, and accessibility.
+	 * Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
+	 * - Displays two tabs (Topics and Sign In) with overflow menu content.
+	 * - Manages keyboard navigation, focus trapping, and accessibility.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
 	 */
 	interface OntarioHeaderMenuTabs {
 		/**
@@ -626,23 +721,29 @@ export namespace Components {
 		topicsMenuItems: MenuItem[] | string;
 	}
 	/**
-	 * Overflow Menu Component
-	 * Displays a dropdown menu of links. Can operate in two modes:
-	 * ## Standalone Mode
+	 * Ontario Header Overflow Menu displays overflow navigation links for header contexts.
+	 * It can operate in two modes:
+	 * ### Standalone Mode
 	 * Used when placed directly in the header (desktop view).
 	 * - Manages its own open/close state via `menuButtonToggled` event
 	 * - Automatically focuses first menu item when opened
 	 * - Sets up focus trap to keep keyboard navigation within menu
 	 * - Auto-closes when focus leaves the menu area
 	 * - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
-	 * ## Embedded Mode
+	 * ### Embedded Mode
 	 * Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 	 * - Parent component controls open/close state
 	 * - Parent component manages focus trap
 	 * - Menu is always visible when parent tab is active
 	 * - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
-	 * **Mode Detection**: Auto-detected based on DOM position (no prop needed).
-	 * Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * ### Mode Detection
+	 * - Auto-detected based on DOM position (no prop needed).
+	 * - Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
 	 */
 	interface OntarioHeaderOverflowMenu {
 		/**
@@ -666,6 +767,12 @@ export namespace Components {
 		 */
 		returnFocusToTriggerOnLastTab?: boolean;
 	}
+	/**
+	 * Ontario Hint Expander reveals optional supporting guidance on demand.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+	 */
 	interface OntarioHintExpander {
 		/**
 		 * Content to display as the hint, once the expander is toggled open. Please note that any content that is passed into this prop will only be displayed as a string. If you would like to add HTML content, supply child content to the component.
@@ -687,7 +794,11 @@ export namespace Components {
 		hintContentType?: HintContentType;
 	}
 	/**
+	 * Ontario Hint Text provides concise supporting instructions for form controls.
 	 * Use hint text to help users understand how to complete fields in a form.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
 	 */
 	interface OntarioHintText {
 		/**
@@ -2673,6 +2784,12 @@ export namespace Components {
 		 */
 		isDecorative: boolean;
 	}
+	/**
+	 * Ontario Input captures single-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 */
 	interface OntarioInput {
 		/**
 		 * The text to display as the input label
@@ -2763,6 +2880,11 @@ export namespace Components {
 		 */
 		value?: string;
 	}
+	/**
+	 * Ontario Language Toggle switches the interface between supported languages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+	 */
 	interface OntarioLanguageToggle {
 		/**
 		 * A custom function to pass to the language toggle button.  This is optional.
@@ -2782,6 +2904,12 @@ export namespace Components {
 		 */
 		url?: string;
 	}
+	/**
+	 * Ontario Loading Indicator communicates in-progress loading states.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/loading-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+	 */
 	interface OntarioLoadingIndicator {
 		/**
 		 * A boolean value to determine whether the loading indicator overlay covers the full page or not. By default, this is set to `true`.  If set to `false`, the loading indicator overlay will be positioned absolutely relative to its container. Note that this will only work if the containing element has a style rule specifying it to be positioned relatively.
@@ -2813,6 +2941,7 @@ export namespace Components {
 	 * For component selection guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
 	 */
 	interface OntarioPageAlert {
 		/**
@@ -2832,6 +2961,12 @@ export namespace Components {
 		 */
 		type: PageAlertType;
 	}
+	/**
+	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 */
 	interface OntarioRadioButtons {
 		/**
 		 * The text to display for the radio button legend.
@@ -2882,6 +3017,12 @@ export namespace Components {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Search Box captures and submits search queries.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/search-box.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 */
 	interface OntarioSearchBox {
 		/**
 		 * The text to display as the input label
@@ -2932,6 +3073,12 @@ export namespace Components {
 		 */
 		value?: string;
 	}
+	/**
+	 * Ontario Step Indicator communicates progress through multi-step flows.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/step-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+	 */
 	interface OntarioStepIndicator {
 		/**
 		 * URL for the back element to set a path for where the link will lead.  If a URL is passed in, the back element will display as an anchor tag. The back element will require either the backButtonURL prop or the customOnClick prop to be passed in order for the back element to display.
@@ -2963,6 +3110,12 @@ export namespace Components {
 		 */
 		showBackButton?: boolean;
 	}
+	/**
+	 * Ontario Table presents structured tabular data with accessible semantics.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/tables.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+	 */
 	interface OntarioTable {
 		/**
 		 * Specifies the caption (or title) of the table.  This is optional.
@@ -2994,6 +3147,12 @@ export namespace Components {
 		 */
 		zebraStripes?: 'auto' | 'disabled' | 'enabled' | undefined;
 	}
+	/**
+	 * Ontario Task represents an individual task item and status within a task list.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+	 */
 	interface OntarioTask {
 		/**
 		 * Disables the task link when set to `true`.  Default is `false`, meaning the link will be active if provided.
@@ -3031,6 +3190,12 @@ export namespace Components {
 		 */
 		taskStatus: TaskStatuses;
 	}
+	/**
+	 * Ontario Task List groups and summarizes related tasks.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+	 */
 	interface OntarioTaskList {
 		/**
 		 * Allows consumers to define the heading level for the task list component.  Accepts 'h1', 'h2', 'h3' or 'h4'. Default is 'h2'.
@@ -3047,6 +3212,12 @@ export namespace Components {
 		 */
 		language?: Language;
 	}
+	/**
+	 * Ontario Textarea captures multi-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 */
 	interface OntarioTextarea {
 		/**
 		 * The text to display as the textarea label.
@@ -3161,6 +3332,12 @@ declare global {
 	interface HTMLOntarioAccordionElementEventMap {
 		accordionChange: AccordionChangeDetail;
 	}
+	/**
+	 * Ontario Accordion presents collapsible sections of content.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/accordions.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+	 */
 	interface HTMLOntarioAccordionElement extends Components.OntarioAccordion, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioAccordionElementEventMap>(
 			type: K,
@@ -3225,21 +3402,45 @@ declare global {
 		prototype: HTMLOntarioAsideElement;
 		new (): HTMLOntarioAsideElement;
 	};
+	/**
+	 * Ontario Back to Top helps users quickly return to the top of long pages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/back-to-top.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+	 */
 	interface HTMLOntarioBackToTopElement extends Components.OntarioBackToTop, HTMLStencilElement {}
 	var HTMLOntarioBackToTopElement: {
 		prototype: HTMLOntarioBackToTopElement;
 		new (): HTMLOntarioBackToTopElement;
 	};
+	/**
+	 * Ontario Badge displays concise status labels and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/badges.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+	 */
 	interface HTMLOntarioBadgeElement extends Components.OntarioBadge, HTMLStencilElement {}
 	var HTMLOntarioBadgeElement: {
 		prototype: HTMLOntarioBadgeElement;
 		new (): HTMLOntarioBadgeElement;
 	};
+	/**
+	 * Ontario Blockquote displays quoted content with optional attribution.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/blockquote.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+	 */
 	interface HTMLOntarioBlockquoteElement extends Components.OntarioBlockquote, HTMLStencilElement {}
 	var HTMLOntarioBlockquoteElement: {
 		prototype: HTMLOntarioBlockquoteElement;
 		new (): HTMLOntarioBlockquoteElement;
 	};
+	/**
+	 * Ontario Button triggers actions and supports button or link behavior.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 */
 	interface HTMLOntarioButtonElement extends Components.OntarioButton, HTMLStencilElement {}
 	var HTMLOntarioButtonElement: {
 		prototype: HTMLOntarioButtonElement;
@@ -3257,11 +3458,22 @@ declare global {
 		prototype: HTMLOntarioCalloutElement;
 		new (): HTMLOntarioCalloutElement;
 	};
+	/**
+	 * Ontario Card displays linked content summaries with optional media and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/cards.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+	 */
 	interface HTMLOntarioCardElement extends Components.OntarioCard, HTMLStencilElement {}
 	var HTMLOntarioCardElement: {
 		prototype: HTMLOntarioCardElement;
 		new (): HTMLOntarioCardElement;
 	};
+	/**
+	 * Ontario Card Collection lays out multiple cards in a responsive grid.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+	 */
 	interface HTMLOntarioCardCollectionElement extends Components.OntarioCardCollection, HTMLStencilElement {}
 	var HTMLOntarioCardCollectionElement: {
 		prototype: HTMLOntarioCardCollectionElement;
@@ -3273,6 +3485,12 @@ declare global {
 		checkboxOnFocus: InputFocusBlurEvent;
 		inputErrorOccurred: { errorMessage: string };
 	}
+	/**
+	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 */
 	interface HTMLOntarioCheckboxesElement extends Components.OntarioCheckboxes, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioCheckboxesElementEventMap>(
 			type: K,
@@ -3325,6 +3543,12 @@ declare global {
 		prototype: HTMLOntarioCheckboxesElement;
 		new (): HTMLOntarioCheckboxesElement;
 	};
+	/**
+	 * Ontario Critical Alert communicates urgent, high-priority emergency information.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/critical-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+	 */
 	interface HTMLOntarioCriticalAlertElement extends Components.OntarioCriticalAlert, HTMLStencilElement {}
 	var HTMLOntarioCriticalAlertElement: {
 		prototype: HTMLOntarioCriticalAlertElement;
@@ -3343,6 +3567,12 @@ declare global {
 		inputOnFocus: DateInputFieldType;
 		inputErrorOccurred: { inputId: string; errorMessage: string };
 	}
+	/**
+	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dates.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 */
 	interface HTMLOntarioDateInputElement extends Components.OntarioDateInput, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioDateInputElementEventMap>(
 			type: K,
@@ -3401,6 +3631,12 @@ declare global {
 		dropdownOnFocus: InputFocusBlurEvent;
 		inputErrorOccurred: { errorMessage: string };
 	}
+	/**
+	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 */
 	interface HTMLOntarioDropdownListElement extends Components.OntarioDropdownList, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioDropdownListElementEventMap>(
 			type: K,
@@ -3453,16 +3689,34 @@ declare global {
 		prototype: HTMLOntarioDropdownListElement;
 		new (): HTMLOntarioDropdownListElement;
 	};
+	/**
+	 * Ontario Fieldset groups related form controls under a shared legend.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/fieldsets.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+	 */
 	interface HTMLOntarioFieldsetElement extends Components.OntarioFieldset, HTMLStencilElement {}
 	var HTMLOntarioFieldsetElement: {
 		prototype: HTMLOntarioFieldsetElement;
 		new (): HTMLOntarioFieldsetElement;
 	};
+	/**
+	 * Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/simple-footer.html
+	 * - https://designsystem.ontario.ca/components/detail/expanded-footer.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+	 */
 	interface HTMLOntarioFooterElement extends Components.OntarioFooter, HTMLStencilElement {}
 	var HTMLOntarioFooterElement: {
 		prototype: HTMLOntarioFooterElement;
 		new (): HTMLOntarioFooterElement;
 	};
+	/**
+	 * Ontario Form Container applies consistent spacing between grouped form elements.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+	 */
 	interface HTMLOntarioFormContainerElement extends Components.OntarioFormContainer, HTMLStencilElement {}
 	var HTMLOntarioFormContainerElement: {
 		prototype: HTMLOntarioFormContainerElement;
@@ -3471,6 +3725,14 @@ declare global {
 	interface HTMLOntarioHeaderElementEventMap {
 		menuButtonToggled: boolean;
 	}
+	/**
+	 * Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+	 */
 	interface HTMLOntarioHeaderElement extends Components.OntarioHeader, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioHeaderElementEventMap>(
 			type: K,
@@ -3529,10 +3791,14 @@ declare global {
 		focusMenuButton: void;
 	}
 	/**
-	 * Ontario Header Menu Tabs Component
-	 * Provides a tabbed navigation interface for mobile/tablet views.
-	 * Displays two tabs (Topics and Sign In) with overflow menu content.
-	 * Manages keyboard navigation, focus trapping, and accessibility.
+	 * Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
+	 * - Displays two tabs (Topics and Sign In) with overflow menu content.
+	 * - Manages keyboard navigation, focus trapping, and accessibility.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
 	 */
 	interface HTMLOntarioHeaderMenuTabsElement extends Components.OntarioHeaderMenuTabs, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioHeaderMenuTabsElementEventMap>(
@@ -3594,23 +3860,29 @@ declare global {
 		menuButtonTabPressed: void;
 	}
 	/**
-	 * Overflow Menu Component
-	 * Displays a dropdown menu of links. Can operate in two modes:
-	 * ## Standalone Mode
+	 * Ontario Header Overflow Menu displays overflow navigation links for header contexts.
+	 * It can operate in two modes:
+	 * ### Standalone Mode
 	 * Used when placed directly in the header (desktop view).
 	 * - Manages its own open/close state via `menuButtonToggled` event
 	 * - Automatically focuses first menu item when opened
 	 * - Sets up focus trap to keep keyboard navigation within menu
 	 * - Auto-closes when focus leaves the menu area
 	 * - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
-	 * ## Embedded Mode
+	 * ### Embedded Mode
 	 * Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 	 * - Parent component controls open/close state
 	 * - Parent component manages focus trap
 	 * - Menu is always visible when parent tab is active
 	 * - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
-	 * **Mode Detection**: Auto-detected based on DOM position (no prop needed).
-	 * Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * ### Mode Detection
+	 * - Auto-detected based on DOM position (no prop needed).
+	 * - Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
 	 */
 	interface HTMLOntarioHeaderOverflowMenuElement extends Components.OntarioHeaderOverflowMenu, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioHeaderOverflowMenuElementEventMap>(
@@ -3667,6 +3939,12 @@ declare global {
 	interface HTMLOntarioHintExpanderElementEventMap {
 		toggleExpanderEvent: MouseEvent | KeyboardEvent;
 	}
+	/**
+	 * Ontario Hint Expander reveals optional supporting guidance on demand.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+	 */
 	interface HTMLOntarioHintExpanderElement extends Components.OntarioHintExpander, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioHintExpanderElementEventMap>(
 			type: K,
@@ -3720,7 +3998,11 @@ declare global {
 		new (): HTMLOntarioHintExpanderElement;
 	};
 	/**
+	 * Ontario Hint Text provides concise supporting instructions for form controls.
 	 * Use hint text to help users understand how to complete fields in a form.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
 	 */
 	interface HTMLOntarioHintTextElement extends Components.OntarioHintText, HTMLStencilElement {}
 	var HTMLOntarioHintTextElement: {
@@ -4335,6 +4617,12 @@ declare global {
 		inputOnFocus: InputFocusBlurEvent;
 		inputErrorOccurred: { inputId: string; errorMessage: string };
 	}
+	/**
+	 * Ontario Input captures single-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 */
 	interface HTMLOntarioInputElement extends Components.OntarioInput, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioInputElementEventMap>(
 			type: K,
@@ -4385,6 +4673,11 @@ declare global {
 		setAppLanguage: Language;
 		headerLanguageToggled: HeaderLanguageToggleEventDetails;
 	}
+	/**
+	 * Ontario Language Toggle switches the interface between supported languages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+	 */
 	interface HTMLOntarioLanguageToggleElement extends Components.OntarioLanguageToggle, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioLanguageToggleElementEventMap>(
 			type: K,
@@ -4437,6 +4730,12 @@ declare global {
 		prototype: HTMLOntarioLanguageToggleElement;
 		new (): HTMLOntarioLanguageToggleElement;
 	};
+	/**
+	 * Ontario Loading Indicator communicates in-progress loading states.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/loading-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+	 */
 	interface HTMLOntarioLoadingIndicatorElement extends Components.OntarioLoadingIndicator, HTMLStencilElement {}
 	var HTMLOntarioLoadingIndicatorElement: {
 		prototype: HTMLOntarioLoadingIndicatorElement;
@@ -4448,6 +4747,7 @@ declare global {
 	 * For component selection guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
 	 */
 	interface HTMLOntarioPageAlertElement extends Components.OntarioPageAlert, HTMLStencilElement {}
 	var HTMLOntarioPageAlertElement: {
@@ -4460,6 +4760,12 @@ declare global {
 		radioOnFocus: InputFocusBlurEvent;
 		inputErrorOccurred: { errorMessage: string };
 	}
+	/**
+	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 */
 	interface HTMLOntarioRadioButtonsElement extends Components.OntarioRadioButtons, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioRadioButtonsElementEventMap>(
 			type: K,
@@ -4519,6 +4825,12 @@ declare global {
 		inputOnBlur: InputFocusBlurEvent;
 		inputOnFocus: InputFocusBlurEvent;
 	}
+	/**
+	 * Ontario Search Box captures and submits search queries.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/search-box.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 */
 	interface HTMLOntarioSearchBoxElement extends Components.OntarioSearchBox, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioSearchBoxElementEventMap>(
 			type: K,
@@ -4571,21 +4883,45 @@ declare global {
 		prototype: HTMLOntarioSearchBoxElement;
 		new (): HTMLOntarioSearchBoxElement;
 	};
+	/**
+	 * Ontario Step Indicator communicates progress through multi-step flows.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/step-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+	 */
 	interface HTMLOntarioStepIndicatorElement extends Components.OntarioStepIndicator, HTMLStencilElement {}
 	var HTMLOntarioStepIndicatorElement: {
 		prototype: HTMLOntarioStepIndicatorElement;
 		new (): HTMLOntarioStepIndicatorElement;
 	};
+	/**
+	 * Ontario Table presents structured tabular data with accessible semantics.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/tables.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+	 */
 	interface HTMLOntarioTableElement extends Components.OntarioTable, HTMLStencilElement {}
 	var HTMLOntarioTableElement: {
 		prototype: HTMLOntarioTableElement;
 		new (): HTMLOntarioTableElement;
 	};
+	/**
+	 * Ontario Task represents an individual task item and status within a task list.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+	 */
 	interface HTMLOntarioTaskElement extends Components.OntarioTask, HTMLStencilElement {}
 	var HTMLOntarioTaskElement: {
 		prototype: HTMLOntarioTaskElement;
 		new (): HTMLOntarioTaskElement;
 	};
+	/**
+	 * Ontario Task List groups and summarizes related tasks.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+	 */
 	interface HTMLOntarioTaskListElement extends Components.OntarioTaskList, HTMLStencilElement {}
 	var HTMLOntarioTaskListElement: {
 		prototype: HTMLOntarioTaskListElement;
@@ -4598,6 +4934,12 @@ declare global {
 		inputOnFocus: InputFocusBlurEvent;
 		inputErrorOccurred: { inputId: string; errorMessage: string };
 	}
+	/**
+	 * Ontario Textarea captures multi-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 */
 	interface HTMLOntarioTextareaElement extends Components.OntarioTextarea, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioTextareaElementEventMap>(
 			type: K,
@@ -4805,6 +5147,12 @@ declare global {
 	}
 }
 declare namespace LocalJSX {
+	/**
+	 * Ontario Accordion presents collapsible sections of content.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/accordions.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+	 */
 	interface OntarioAccordion {
 		/**
 		 * Used to include individual accordion data for the accordion component. Accepts an array of Accordion (@see Accordion) items or a JSON string of that array.  The `content` is rendered either as plain text or HTML depending on `accordionContentType`.
@@ -4862,12 +5210,24 @@ declare namespace LocalJSX {
 		 */
 		highlightColour?: HighlightColourOptions;
 	}
+	/**
+	 * Ontario Back to Top helps users quickly return to the top of long pages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/back-to-top.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+	 */
 	interface OntarioBackToTop {
 		/**
 		 * The language of the component. This is used for translations, and is by default set through event listeners checking for a language property from the header. If no language prop is passed, it will default to English.
 		 */
 		language?: Language;
 	}
+	/**
+	 * Ontario Badge displays concise status labels and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/badges.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+	 */
 	interface OntarioBadge {
 		/**
 		 * An aria label for screen readers.  Used to provide more context to screen readers if necessary.  This property is optional.
@@ -4884,6 +5244,12 @@ declare namespace LocalJSX {
 		 */
 		label?: string;
 	}
+	/**
+	 * Ontario Blockquote displays quoted content with optional attribution.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/blockquote.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+	 */
 	interface OntarioBlockquote {
 		/**
 		 * Optional text to be displayed as the attribution (the author) of the quote.
@@ -4898,6 +5264,12 @@ declare namespace LocalJSX {
 		 */
 		quote?: string;
 	}
+	/**
+	 * Ontario Button triggers actions and supports button or link behavior.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 */
 	interface OntarioButton {
 		/**
 		 * Provides more context as to what the button interaction is doing. This should only be used for accessibility purposes, if the button interaction requires more description than what the text provides.   This is optional.
@@ -4968,6 +5340,12 @@ declare namespace LocalJSX {
 		 */
 		highlightColour?: HighlightColourOptions;
 	}
+	/**
+	 * Ontario Card displays linked content summaries with optional media and metadata.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/cards.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+	 */
 	interface OntarioCard {
 		/**
 		 * Provides more context as to what the card interaction is doing. This should only be used for accessibility purposes, if the card interaction requires more * * description than what the text provides.  This is optional.
@@ -5023,6 +5401,11 @@ declare namespace LocalJSX {
 		 */
 		layoutDirection?: LayoutDirection;
 	}
+	/**
+	 * Ontario Card Collection lays out multiple cards in a responsive grid.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+	 */
 	interface OntarioCardCollection {
 		/**
 		 * The number of cards to display per row.  If no number is passed, it will default to 3.
@@ -5030,6 +5413,12 @@ declare namespace LocalJSX {
 		 */
 		cardsPerRow?: CardsPerRow;
 	}
+	/**
+	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 */
 	interface OntarioCheckboxes {
 		/**
 		 * The text to display for the checkbox legend.
@@ -5096,6 +5485,12 @@ declare namespace LocalJSX {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Critical Alert communicates urgent, high-priority emergency information.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/critical-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+	 */
 	interface OntarioCriticalAlert {
 		/**
 		 * Content for critical alert message. It can be either string or HTML content. The content is already wrapped in a paragraph tag, so if using HTML content, the paragraph tag can be ommitted.
@@ -5103,6 +5498,12 @@ declare namespace LocalJSX {
 		 */
 		content?: string | HTMLElement;
 	}
+	/**
+	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dates.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 */
 	interface OntarioDateInput {
 		/**
 		 * The text to display as the input label
@@ -5178,6 +5579,12 @@ declare namespace LocalJSX {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 */
 	interface OntarioDropdownList {
 		/**
 		 * The text to display for the dropdown list label.
@@ -5254,6 +5661,12 @@ declare namespace LocalJSX {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Fieldset groups related form controls under a shared legend.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/fieldsets.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+	 */
 	interface OntarioFieldset {
 		/**
 		 * The text value used for the legend of the fieldset.
@@ -5265,6 +5678,13 @@ declare namespace LocalJSX {
 		 */
 		legendSize?: CaptionType;
 	}
+	/**
+	 * Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/simple-footer.html
+	 * - https://designsystem.ontario.ca/components/detail/expanded-footer.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+	 */
 	interface OntarioFooter {
 		/**
 		 * The base path to an assets folder containing the Design System assets
@@ -5301,6 +5721,11 @@ declare namespace LocalJSX {
 		 */
 		type?: OntarioFooterType;
 	}
+	/**
+	 * Ontario Form Container applies consistent spacing between grouped form elements.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+	 */
 	interface OntarioFormContainer {
 		/**
 		 * Defines the gap (bottom margin) between slotted form elements. If no gap prop is provided, it will default to 'default'.
@@ -5308,6 +5733,14 @@ declare namespace LocalJSX {
 		 */
 		gap?: 'default' | 'condensed';
 	}
+	/**
+	 * Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+	 */
 	interface OntarioHeader {
 		/**
 		 * Information pertaining to the application and ServiceOntario headers.  For the 'application' header type, this includes the application name, URL and optional props for the number of links in the subheader for desktop, tablet, and mobile views.  For the 'serviceOntario' header type, the 'title' property is used as the service name displayed in the subheader.
@@ -5361,10 +5794,14 @@ declare namespace LocalJSX {
 		type?: OntarioHeaderType;
 	}
 	/**
-	 * Ontario Header Menu Tabs Component
-	 * Provides a tabbed navigation interface for mobile/tablet views.
-	 * Displays two tabs (Topics and Sign In) with overflow menu content.
-	 * Manages keyboard navigation, focus trapping, and accessibility.
+	 * Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
+	 * - Displays two tabs (Topics and Sign In) with overflow menu content.
+	 * - Manages keyboard navigation, focus trapping, and accessibility.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
 	 */
 	interface OntarioHeaderMenuTabs {
 		/**
@@ -5399,23 +5836,29 @@ declare namespace LocalJSX {
 		topicsMenuItems?: MenuItem[] | string;
 	}
 	/**
-	 * Overflow Menu Component
-	 * Displays a dropdown menu of links. Can operate in two modes:
-	 * ## Standalone Mode
+	 * Ontario Header Overflow Menu displays overflow navigation links for header contexts.
+	 * It can operate in two modes:
+	 * ### Standalone Mode
 	 * Used when placed directly in the header (desktop view).
 	 * - Manages its own open/close state via `menuButtonToggled` event
 	 * - Automatically focuses first menu item when opened
 	 * - Sets up focus trap to keep keyboard navigation within menu
 	 * - Auto-closes when focus leaves the menu area
 	 * - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
-	 * ## Embedded Mode
+	 * ### Embedded Mode
 	 * Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 	 * - Parent component controls open/close state
 	 * - Parent component manages focus trap
 	 * - Menu is always visible when parent tab is active
 	 * - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
-	 * **Mode Detection**: Auto-detected based on DOM position (no prop needed).
-	 * Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * ### Mode Detection
+	 * - Auto-detected based on DOM position (no prop needed).
+	 * - Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+	 * - https://designsystem.ontario.ca/components/detail/application-header.html
+	 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
 	 */
 	interface OntarioHeaderOverflowMenu {
 		/**
@@ -5459,6 +5902,12 @@ declare namespace LocalJSX {
 		 */
 		returnFocusToTriggerOnLastTab?: boolean;
 	}
+	/**
+	 * Ontario Hint Expander reveals optional supporting guidance on demand.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+	 */
 	interface OntarioHintExpander {
 		/**
 		 * Content to display as the hint, once the expander is toggled open. Please note that any content that is passed into this prop will only be displayed as a string. If you would like to add HTML content, supply child content to the component.
@@ -5484,7 +5933,11 @@ declare namespace LocalJSX {
 		onToggleExpanderEvent?: (event: OntarioHintExpanderCustomEvent<MouseEvent | KeyboardEvent>) => void;
 	}
 	/**
+	 * Ontario Hint Text provides concise supporting instructions for form controls.
 	 * Use hint text to help users understand how to complete fields in a form.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
 	 */
 	interface OntarioHintText {
 		/**
@@ -7465,6 +7918,12 @@ declare namespace LocalJSX {
 		 */
 		isDecorative?: boolean;
 	}
+	/**
+	 * Ontario Input captures single-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 */
 	interface OntarioInput {
 		/**
 		 * The text to display as the input label
@@ -7575,6 +8034,11 @@ declare namespace LocalJSX {
 		 */
 		value?: string;
 	}
+	/**
+	 * Ontario Language Toggle switches the interface between supported languages.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+	 */
 	interface OntarioLanguageToggle {
 		/**
 		 * A custom function to pass to the language toggle button.  This is optional.
@@ -7602,6 +8066,12 @@ declare namespace LocalJSX {
 		 */
 		url?: string;
 	}
+	/**
+	 * Ontario Loading Indicator communicates in-progress loading states.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/loading-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+	 */
 	interface OntarioLoadingIndicator {
 		/**
 		 * A boolean value to determine whether the loading indicator overlay covers the full page or not. By default, this is set to `true`.  If set to `false`, the loading indicator overlay will be positioned absolutely relative to its container. Note that this will only work if the containing element has a style rule specifying it to be positioned relatively.
@@ -7633,6 +8103,7 @@ declare namespace LocalJSX {
 	 * For component selection guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
 	 */
 	interface OntarioPageAlert {
 		/**
@@ -7652,6 +8123,12 @@ declare namespace LocalJSX {
 		 */
 		type?: PageAlertType;
 	}
+	/**
+	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 */
 	interface OntarioRadioButtons {
 		/**
 		 * The text to display for the radio button legend.
@@ -7718,6 +8195,12 @@ declare namespace LocalJSX {
 		 */
 		required?: boolean;
 	}
+	/**
+	 * Ontario Search Box captures and submits search queries.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/search-box.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 */
 	interface OntarioSearchBox {
 		/**
 		 * The text to display as the input label
@@ -7789,6 +8272,12 @@ declare namespace LocalJSX {
 		 */
 		value?: string;
 	}
+	/**
+	 * Ontario Step Indicator communicates progress through multi-step flows.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/step-indicator.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+	 */
 	interface OntarioStepIndicator {
 		/**
 		 * URL for the back element to set a path for where the link will lead.  If a URL is passed in, the back element will display as an anchor tag. The back element will require either the backButtonURL prop or the customOnClick prop to be passed in order for the back element to display.
@@ -7820,6 +8309,12 @@ declare namespace LocalJSX {
 		 */
 		showBackButton?: boolean;
 	}
+	/**
+	 * Ontario Table presents structured tabular data with accessible semantics.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/tables.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+	 */
 	interface OntarioTable {
 		/**
 		 * Specifies the caption (or title) of the table.  This is optional.
@@ -7851,6 +8346,12 @@ declare namespace LocalJSX {
 		 */
 		zebraStripes?: 'auto' | 'disabled' | 'enabled' | undefined;
 	}
+	/**
+	 * Ontario Task represents an individual task item and status within a task list.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+	 */
 	interface OntarioTask {
 		/**
 		 * Disables the task link when set to `true`.  Default is `false`, meaning the link will be active if provided.
@@ -7888,6 +8389,12 @@ declare namespace LocalJSX {
 		 */
 		taskStatus?: TaskStatuses;
 	}
+	/**
+	 * Ontario Task List groups and summarizes related tasks.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/task-list.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+	 */
 	interface OntarioTaskList {
 		/**
 		 * Allows consumers to define the heading level for the task list component.  Accepts 'h1', 'h2', 'h3' or 'h4'. Default is 'h2'.
@@ -7904,6 +8411,12 @@ declare namespace LocalJSX {
 		 */
 		language?: Language;
 	}
+	/**
+	 * Ontario Textarea captures multi-line text input.
+	 * For component guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 */
 	interface OntarioTextarea {
 		/**
 		 * The text to display as the textarea label.
@@ -8139,6 +8652,12 @@ export { LocalJSX as JSX };
 declare module '@stencil/core' {
 	export namespace JSX {
 		interface IntrinsicElements {
+			/**
+			 * Ontario Accordion presents collapsible sections of content.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/accordions.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+			 */
 			'ontario-accordion': LocalJSX.OntarioAccordion & JSXBase.HTMLAttributes<HTMLOntarioAccordionElement>;
 			/**
 			 * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
@@ -8148,9 +8667,33 @@ declare module '@stencil/core' {
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
 			 */
 			'ontario-aside': LocalJSX.OntarioAside & JSXBase.HTMLAttributes<HTMLOntarioAsideElement>;
+			/**
+			 * Ontario Back to Top helps users quickly return to the top of long pages.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/back-to-top.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+			 */
 			'ontario-back-to-top': LocalJSX.OntarioBackToTop & JSXBase.HTMLAttributes<HTMLOntarioBackToTopElement>;
+			/**
+			 * Ontario Badge displays concise status labels and metadata.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/badges.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+			 */
 			'ontario-badge': LocalJSX.OntarioBadge & JSXBase.HTMLAttributes<HTMLOntarioBadgeElement>;
+			/**
+			 * Ontario Blockquote displays quoted content with optional attribution.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/blockquote.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+			 */
 			'ontario-blockquote': LocalJSX.OntarioBlockquote & JSXBase.HTMLAttributes<HTMLOntarioBlockquoteElement>;
+			/**
+			 * Ontario Button triggers actions and supports button or link behavior.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+			 */
 			'ontario-button': LocalJSX.OntarioButton & JSXBase.HTMLAttributes<HTMLOntarioButtonElement>;
 			/**
 			 * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
@@ -8160,49 +8703,130 @@ declare module '@stencil/core' {
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
 			 */
 			'ontario-callout': LocalJSX.OntarioCallout & JSXBase.HTMLAttributes<HTMLOntarioCalloutElement>;
+			/**
+			 * Ontario Card displays linked content summaries with optional media and metadata.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/cards.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+			 */
 			'ontario-card': LocalJSX.OntarioCard & JSXBase.HTMLAttributes<HTMLOntarioCardElement>;
+			/**
+			 * Ontario Card Collection lays out multiple cards in a responsive grid.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+			 */
 			'ontario-card-collection': LocalJSX.OntarioCardCollection &
 				JSXBase.HTMLAttributes<HTMLOntarioCardCollectionElement>;
+			/**
+			 * Ontario Checkboxes collects one or more selections from a defined option set.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+			 */
 			'ontario-checkboxes': LocalJSX.OntarioCheckboxes & JSXBase.HTMLAttributes<HTMLOntarioCheckboxesElement>;
+			/**
+			 * Ontario Critical Alert communicates urgent, high-priority emergency information.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/critical-alerts.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+			 */
 			'ontario-critical-alert': LocalJSX.OntarioCriticalAlert & JSXBase.HTMLAttributes<HTMLOntarioCriticalAlertElement>;
+			/**
+			 * Ontario Date Input captures day, month, and year values as a single date field.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/dates.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+			 */
 			'ontario-date-input': LocalJSX.OntarioDateInput & JSXBase.HTMLAttributes<HTMLOntarioDateInputElement>;
+			/**
+			 * Ontario Dropdown List presents a selectable list of predefined options.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+			 */
 			'ontario-dropdown-list': LocalJSX.OntarioDropdownList & JSXBase.HTMLAttributes<HTMLOntarioDropdownListElement>;
+			/**
+			 * Ontario Fieldset groups related form controls under a shared legend.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/fieldsets.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+			 */
 			'ontario-fieldset': LocalJSX.OntarioFieldset & JSXBase.HTMLAttributes<HTMLOntarioFieldsetElement>;
+			/**
+			 * Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/simple-footer.html
+			 * - https://designsystem.ontario.ca/components/detail/expanded-footer.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+			 */
 			'ontario-footer': LocalJSX.OntarioFooter & JSXBase.HTMLAttributes<HTMLOntarioFooterElement>;
+			/**
+			 * Ontario Form Container applies consistent spacing between grouped form elements.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+			 */
 			'ontario-form-container': LocalJSX.OntarioFormContainer & JSXBase.HTMLAttributes<HTMLOntarioFormContainerElement>;
+			/**
+			 * Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+			 * - https://designsystem.ontario.ca/components/detail/application-header.html
+			 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+			 */
 			'ontario-header': LocalJSX.OntarioHeader & JSXBase.HTMLAttributes<HTMLOntarioHeaderElement>;
 			/**
-			 * Ontario Header Menu Tabs Component
-			 * Provides a tabbed navigation interface for mobile/tablet views.
-			 * Displays two tabs (Topics and Sign In) with overflow menu content.
-			 * Manages keyboard navigation, focus trapping, and accessibility.
+			 * Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
+			 * - Displays two tabs (Topics and Sign In) with overflow menu content.
+			 * - Manages keyboard navigation, focus trapping, and accessibility.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+			 * - https://designsystem.ontario.ca/components/detail/application-header.html
+			 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
 			 */
 			'ontario-header-menu-tabs': LocalJSX.OntarioHeaderMenuTabs &
 				JSXBase.HTMLAttributes<HTMLOntarioHeaderMenuTabsElement>;
 			/**
-			 * Overflow Menu Component
-			 * Displays a dropdown menu of links. Can operate in two modes:
-			 * ## Standalone Mode
+			 * Ontario Header Overflow Menu displays overflow navigation links for header contexts.
+			 * It can operate in two modes:
+			 * ### Standalone Mode
 			 * Used when placed directly in the header (desktop view).
 			 * - Manages its own open/close state via `menuButtonToggled` event
 			 * - Automatically focuses first menu item when opened
 			 * - Sets up focus trap to keep keyboard navigation within menu
 			 * - Auto-closes when focus leaves the menu area
 			 * - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
-			 * ## Embedded Mode
+			 * ### Embedded Mode
 			 * Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 			 * - Parent component controls open/close state
 			 * - Parent component manages focus trap
 			 * - Menu is always visible when parent tab is active
 			 * - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
-			 * **Mode Detection**: Auto-detected based on DOM position (no prop needed).
-			 * Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+			 * ### Mode Detection
+			 * - Auto-detected based on DOM position (no prop needed).
+			 * - Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+			 * - https://designsystem.ontario.ca/components/detail/application-header.html
+			 * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
 			 */
 			'ontario-header-overflow-menu': LocalJSX.OntarioHeaderOverflowMenu &
 				JSXBase.HTMLAttributes<HTMLOntarioHeaderOverflowMenuElement>;
+			/**
+			 * Ontario Hint Expander reveals optional supporting guidance on demand.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+			 */
 			'ontario-hint-expander': LocalJSX.OntarioHintExpander & JSXBase.HTMLAttributes<HTMLOntarioHintExpanderElement>;
 			/**
+			 * Ontario Hint Text provides concise supporting instructions for form controls.
 			 * Use hint text to help users understand how to complete fields in a form.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/hint-text.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
 			 */
 			'ontario-hint-text': LocalJSX.OntarioHintText & JSXBase.HTMLAttributes<HTMLOntarioHintTextElement>;
 			'ontario-icon-accessibility': LocalJSX.OntarioIconAccessibility &
@@ -8387,9 +9011,26 @@ declare module '@stencil/core' {
 				JSXBase.HTMLAttributes<HTMLOntarioIconWheelchairElement>;
 			'ontario-icon-wifi': LocalJSX.OntarioIconWifi & JSXBase.HTMLAttributes<HTMLOntarioIconWifiElement>;
 			'ontario-icon-youtube': LocalJSX.OntarioIconYoutube & JSXBase.HTMLAttributes<HTMLOntarioIconYoutubeElement>;
+			/**
+			 * Ontario Input captures single-line text input.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+			 */
 			'ontario-input': LocalJSX.OntarioInput & JSXBase.HTMLAttributes<HTMLOntarioInputElement>;
+			/**
+			 * Ontario Language Toggle switches the interface between supported languages.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+			 */
 			'ontario-language-toggle': LocalJSX.OntarioLanguageToggle &
 				JSXBase.HTMLAttributes<HTMLOntarioLanguageToggleElement>;
+			/**
+			 * Ontario Loading Indicator communicates in-progress loading states.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/loading-indicator.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+			 */
 			'ontario-loading-indicator': LocalJSX.OntarioLoadingIndicator &
 				JSXBase.HTMLAttributes<HTMLOntarioLoadingIndicatorElement>;
 			/**
@@ -8398,14 +9039,57 @@ declare module '@stencil/core' {
 			 * For component selection guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 			 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
 			 */
 			'ontario-page-alert': LocalJSX.OntarioPageAlert & JSXBase.HTMLAttributes<HTMLOntarioPageAlertElement>;
+			/**
+			 * Ontario Radio Buttons captures a single choice from a defined option set.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+			 */
 			'ontario-radio-buttons': LocalJSX.OntarioRadioButtons & JSXBase.HTMLAttributes<HTMLOntarioRadioButtonsElement>;
+			/**
+			 * Ontario Search Box captures and submits search queries.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/search-box.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+			 */
 			'ontario-search-box': LocalJSX.OntarioSearchBox & JSXBase.HTMLAttributes<HTMLOntarioSearchBoxElement>;
+			/**
+			 * Ontario Step Indicator communicates progress through multi-step flows.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/step-indicator.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+			 */
 			'ontario-step-indicator': LocalJSX.OntarioStepIndicator & JSXBase.HTMLAttributes<HTMLOntarioStepIndicatorElement>;
+			/**
+			 * Ontario Table presents structured tabular data with accessible semantics.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/tables.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+			 */
 			'ontario-table': LocalJSX.OntarioTable & JSXBase.HTMLAttributes<HTMLOntarioTableElement>;
+			/**
+			 * Ontario Task represents an individual task item and status within a task list.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/task-list.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+			 */
 			'ontario-task': LocalJSX.OntarioTask & JSXBase.HTMLAttributes<HTMLOntarioTaskElement>;
+			/**
+			 * Ontario Task List groups and summarizes related tasks.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/task-list.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+			 */
 			'ontario-task-list': LocalJSX.OntarioTaskList & JSXBase.HTMLAttributes<HTMLOntarioTaskListElement>;
+			/**
+			 * Ontario Textarea captures multi-line text input.
+			 * For component guidance, see:
+			 * - https://designsystem.ontario.ca/components/detail/text-areas.html
+			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+			 */
 			'ontario-textarea': LocalJSX.OntarioTextarea & JSXBase.HTMLAttributes<HTMLOntarioTextareaElement>;
 		}
 	}

--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/ontario-accordion.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/ontario-accordion.tsx
@@ -11,6 +11,13 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 
 import translations from '../../translations/global.i18n.json';
 
+/**
+ * Ontario Accordion presents collapsible sections of content.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/accordions.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+ */
 @Component({
 	tag: 'ontario-accordion',
 	styleUrl: 'ontario-accordion.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-accordion/readme.md
@@ -167,6 +167,15 @@ These language change events only fire in the browser after hydration. To ensure
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Accordion presents collapsible sections of content.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/accordions.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-accordion/
+
 ## Properties
 
 | Property               | Attribute                | Description                                                                                                                                                                                                                                             | Type                                                 | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
@@ -37,9 +37,15 @@ export class OntarioAside implements CalloutAside {
 	@Prop() headingContent?: string;
 
 	/**
-	 * Optional text to be displayed as the content for the aside component. If a string is passed, it will automatically be nested in a paragraph tag.
+	 * Optional text to be displayed as the content for the aside component.
+	 * Use an aside for related, non-essential information that sits alongside the main task flow.
+	 * If a string is passed, it will automatically be nested in a paragraph tag.
 	 *
 	 * HTML content can also be passed as the child/children of the aside component if additional/different elements for the content are needed.
+	 *
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 	 *
 	 * @example
 	 * <ontario-aside headingType='h3' headingContent='This is the aside heading'><p>This is the first sentence of the aside content.</p><p>This is the second sentence of the aside content.</p></ontario-aside>

--- a/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
@@ -46,6 +46,7 @@ export class OntarioAside implements CalloutAside {
 	 * For component selection guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
 	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
 	 *
 	 * @example
 	 * <ontario-aside headingType='h3' headingContent='This is the aside heading'><p>This is the first sentence of the aside content.</p><p>This is the second sentence of the aside content.</p></ontario-aside>

--- a/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-aside/ontario-aside.tsx
@@ -15,6 +15,14 @@ import {
 import { validateValueAgainstArray } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+ *
+ * For component selection guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+ * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+ */
 @Component({
 	tag: 'ontario-aside',
 	styleUrl: 'ontario-aside.scss',
@@ -37,16 +45,9 @@ export class OntarioAside implements CalloutAside {
 	@Prop() headingContent?: string;
 
 	/**
-	 * Optional text to be displayed as the content for the aside component.
-	 * Use an aside for related, non-essential information that sits alongside the main task flow.
-	 * If a string is passed, it will automatically be nested in a paragraph tag.
+	 * Optional text to be displayed as the content for the aside component. If a string is passed, it will automatically be nested in a paragraph tag.
 	 *
 	 * HTML content can also be passed as the child/children of the aside component if additional/different elements for the content are needed.
-	 *
-	 * For component selection guidance, see:
-	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
-	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
-	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
 	 *
 	 * @example
 	 * <ontario-aside headingType='h3' headingContent='This is the aside heading'><p>This is the first sentence of the aside content.</p><p>This is the second sentence of the aside content.</p></ontario-aside>

--- a/packages/ontario-design-system-component-library/src/components/ontario-aside/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-aside/readme.md
@@ -193,6 +193,16 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Aside is used for related, non-essential information that supports content beside the main task flow.
+
+For component selection guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/callouts-asides.html
+- https://designsystem.ontario.ca/components/detail/page-alerts.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-aside/
+
 ## Properties
 
 | Property             | Attribute              | Description                                                                                                                                                                                                                                                                                | Type                                                                                                       | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/ontario-back-to-top.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/ontario-back-to-top.tsx
@@ -8,6 +8,13 @@ import translations from '../../translations/global.i18n.json';
 import { isClientSideRendering } from '../../utils/common/environment';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Back to Top helps users quickly return to the top of long pages.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/back-to-top.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+ */
 @Component({
 	tag: 'ontario-back-to-top',
 	styleUrl: 'ontario-back-to-top.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-back-to-top/readme.md
@@ -121,6 +121,15 @@ The Ontario Back to Top component is SSR-compatible and renders static markup du
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Back to Top helps users quickly return to the top of long pages.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/back-to-top.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-back-to-top/
+
 ## Properties
 
 | Property   | Attribute  | Description                                                                                                                                                                                                              | Type                        | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-badge/ontario-badge.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-badge/ontario-badge.tsx
@@ -6,6 +6,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { isClientSideRendering } from '../../utils/common/environment';
 import { validateValueAgainstArray } from '../../utils/validation/validation-functions';
 
+/**
+ * Ontario Badge displays concise status labels and metadata.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/badges.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+ */
 @Component({
 	tag: 'ontario-badge',
 	styleUrl: 'ontario-badge.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-badge/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-badge/readme.md
@@ -135,6 +135,15 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Badge displays concise status labels and metadata.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/badges.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-badge/
+
 ## Properties
 
 | Property        | Attribute         | Description                                                                                                               | Type                                                                                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-blockquote/ontario-blockquote.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-blockquote/ontario-blockquote.tsx
@@ -6,6 +6,13 @@ import { validatePropExists } from '../../utils/validation/validation-functions'
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 import { isServerSideRendering } from '../../utils/common/environment';
 
+/**
+ * Ontario Blockquote displays quoted content with optional attribution.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/blockquote.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+ */
 @Component({
 	tag: 'ontario-blockquote',
 	styleUrl: 'ontario-blockquote.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-blockquote/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-blockquote/readme.md
@@ -167,6 +167,15 @@ During SSR, fallback content using `host.textContent` is not reliably available,
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Blockquote displays quoted content with optional attribution.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/blockquote.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-blockquote/
+
 ## Properties
 
 | Property      | Attribute     | Description                                                                                                                                 | Type                  | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
@@ -7,6 +7,13 @@ import { validatePropExists, validateValueAgainstArray } from '../../utils/valid
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 import { isServerSideRendering } from '../../utils/common/environment';
 
+/**
+ * Ontario Button triggers actions and supports button or link behavior.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+ */
 @Component({
 	tag: 'ontario-button',
 	styleUrl: 'ontario-button.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
@@ -350,6 +350,15 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Button triggers actions and supports button or link behavior.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+
 ## Properties
 
 | Property        | Attribute         | Description                                                                                                                                                                                                                                                                          | Type                                                            | Default       |

--- a/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
@@ -46,6 +46,7 @@ export class OntarioCallout implements CalloutAside {
 	 * For component selection guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
 	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
 	 *
 	 * @example
 	 * <ontario-callout headingType='h3' headingContent='This is the callout heading'><p>This is the first sentence of the callout content.</p><p>This is the second sentence of the callout content.</p></ontario-callout>

--- a/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
@@ -15,6 +15,14 @@ import {
 import { validateValueAgainstArray } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+ *
+ * For component selection guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+ * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+ */
 @Component({
 	tag: 'ontario-callout',
 	styleUrl: 'ontario-callout.scss',
@@ -37,16 +45,9 @@ export class OntarioCallout implements CalloutAside {
 	@Prop() headingContent?: string;
 
 	/**
-	 * Optional text to be displayed as the content for the callout component.
-	 * Use a callout for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
-	 * If a string is passed, it will automatically be nested in a paragraph tag.
+	 * Optional text to be displayed as the content for the callout component. If a string is passed, it will automatically be nested in a paragraph tag.
 	 *
 	 * HTML content can also be passed as the child/children of the callout component if additional/different elements for the content are needed.
-	 *
-	 * For component selection guidance, see:
-	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
-	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
-	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
 	 *
 	 * @example
 	 * <ontario-callout headingType='h3' headingContent='This is the callout heading'><p>This is the first sentence of the callout content.</p><p>This is the second sentence of the callout content.</p></ontario-callout>

--- a/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-callout/ontario-callout.tsx
@@ -37,9 +37,15 @@ export class OntarioCallout implements CalloutAside {
 	@Prop() headingContent?: string;
 
 	/**
-	 * Optional text to be displayed as the content for the callout component. If a string is passed, it will automatically be nested in a paragraph tag.
+	 * Optional text to be displayed as the content for the callout component.
+	 * Use a callout for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+	 * If a string is passed, it will automatically be nested in a paragraph tag.
 	 *
 	 * HTML content can also be passed as the child/children of the callout component if additional/different elements for the content are needed.
+	 *
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
 	 *
 	 * @example
 	 * <ontario-callout headingType='h3' headingContent='This is the callout heading'><p>This is the first sentence of the callout content.</p><p>This is the second sentence of the callout content.</p></ontario-callout>

--- a/packages/ontario-design-system-component-library/src/components/ontario-callout/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-callout/readme.md
@@ -177,6 +177,16 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Callout is used for supplementary, in-flow guidance that supports nearby content without elevating to a page-level alert.
+
+For component selection guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/callouts-asides.html
+- https://designsystem.ontario.ca/components/detail/page-alerts.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-callout/
+
 ## Properties
 
 | Property             | Attribute              | Description                                                                                                                                                                                                                                                                                    | Type                                                                                                       | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/ontario-card-collection.tsx
@@ -2,6 +2,12 @@ import { Component, Prop, Element, h, Watch, State } from '@stencil/core';
 import { CardsPerRow } from './ontario-collection-card-types';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Card Collection lays out multiple cards in a responsive grid.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+ */
 @Component({
 	tag: 'ontario-card-collection',
 	styleUrl: 'ontario-card-collection.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-card-collection/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card-collection/readme.md
@@ -141,6 +141,14 @@ Example of a bare-bones `ontario-card-collection` component, with a `cardsPerRow
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Card Collection lays out multiple cards in a responsive grid.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/developer-docs/components/ontario-card-collection/
+
 ## Properties
 
 | Property      | Attribute       | Description                                                                           | Type          | Default |

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
@@ -13,6 +13,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { printArray } from '../../utils/helper/utils';
 import { validateValueAgainstArray } from '../../utils/validation/validation-functions';
 
+/**
+ * Ontario Card displays linked content summaries with optional media and metadata.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/cards.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+ */
 @Component({
 	tag: 'ontario-card',
 	styleUrl: 'ontario-card.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
@@ -264,6 +264,15 @@ For best SSR results:
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Card displays linked content summaries with optional media and metadata.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/cards.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-card/
+
 ## Properties
 
 | Property                      | Attribute                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Type                                                                                                                                                                                                                                                                                                                                                                                     | Default       |

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
@@ -27,6 +27,13 @@ import { default as translations } from '../../translations/global.i18n.json';
 import { ErrorMessage } from '../../utils/components/error-message/error-message';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Checkboxes collects one or more selections from a defined option set.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/checkboxes.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+ */
 @Component({
 	tag: 'ontario-checkboxes',
 	styleUrl: 'ontario-checkboxes.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -397,6 +397,15 @@ The Ontario Checkbox component supports Server-Side Rendering (SSR), but to ensu
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Checkboxes collects one or more selections from a defined option set.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/checkboxes.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                                                                                                                                                                                                                                                                                                                            | Type                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/ontario-critical-alert.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/ontario-critical-alert.tsx
@@ -6,6 +6,13 @@ import OntarioIconCriticalAlertWarning from '../ontario-icon/assets/ontario-icon
 import { validatePropExists } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Critical Alert communicates urgent, high-priority emergency information.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/critical-alerts.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+ */
 @Component({
 	tag: 'ontario-critical-alert',
 	styleUrl: 'ontario-critical-alert.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/readme.md
@@ -135,6 +135,15 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Critical Alert communicates urgent, high-priority emergency information.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/critical-alerts.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-critical-alert/
+
 ## Properties
 
 | Property  | Attribute | Description                                                                                                                                                                                  | Type                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
@@ -14,6 +14,13 @@ import { Caption } from '../../utils/common/input-caption/caption.interface';
 import { emitEvent } from '../../utils/events/event-handler';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Date Input captures day, month, and year values as a single date field.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/dates.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+ */
 @Component({
 	tag: 'ontario-date-input',
 	styleUrl: 'ontario-date-input.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -289,6 +289,15 @@ The Ontario Date Input component is compatible with Server-Side Rendering (SSR),
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Date Input captures day, month, and year values as a single date field.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/dates.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+
 ## Properties
 
 | Property        | Attribute        | Description                                                                                                                                                                                                                                                                                                       | Type                                                                                                             | Default                    |

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
@@ -25,6 +25,13 @@ import { default as translations } from '../../translations/global.i18n.json';
 import { ErrorMessage } from '../../utils/components/error-message/error-message';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Dropdown List presents a selectable list of predefined options.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+ */
 @Component({
 	tag: 'ontario-dropdown-list',
 	styleUrl: 'ontario-dropdown-list.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -458,6 +458,15 @@ The Ontario Dropdown List component supports full server-side rendering, with a 
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Dropdown List presents a selectable list of predefined options.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/dropdown-lists.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+
 ## Properties
 
 | Property             | Attribute               | Description                                                                                                                                                                                                                                                                                                         | Type                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.tsx
@@ -7,6 +7,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { validatePropExists, validateValueAgainstArray } from '../../utils/validation/validation-functions';
 import { OntarioFormContainer, FormGap } from '../../utils/components/form-container/form-container.interface';
 
+/**
+ * Ontario Fieldset groups related form controls under a shared legend.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/fieldsets.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+ */
 @Component({
 	tag: 'ontario-fieldset',
 	styleUrl: 'ontario-fieldset.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/readme.md
@@ -79,6 +79,15 @@ Example of a fieldset component.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Fieldset groups related form controls under a shared legend.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/fieldsets.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-fieldset/
+
 ## Properties
 
 | Property     | Attribute     | Description                                                                  | Type                                | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.tsx
@@ -19,6 +19,14 @@ import { getImageAssetSrcPath } from '../../utils/helper/assets';
 import translations from '../../translations/global.i18n.json';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/simple-footer.html
+ * - https://designsystem.ontario.ca/components/detail/expanded-footer.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+ */
 @Component({
 	tag: 'ontario-footer',
 	styleUrl: 'ontario-footer.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/readme.md
@@ -969,6 +969,16 @@ These language change events only fire in the browser after hydration. To ensure
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Footer renders simple or expanded footer patterns for Ontario sites and applications.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/simple-footer.html
+- https://designsystem.ontario.ca/components/detail/expanded-footer.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-footer/
+
 ## Properties
 
 | Property             | Attribute              | Description                                                                                                                                                                                                         | Type                                                                                                                                           | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-form-container/ontario-form-container.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-form-container/ontario-form-container.tsx
@@ -2,6 +2,12 @@ import { Component, Element, h, Prop } from '@stencil/core';
 
 import { FormGap } from '../../utils/components/form-container/form-container.interface';
 
+/**
+ * Ontario Form Container applies consistent spacing between grouped form elements.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+ */
 @Component({
 	tag: 'ontario-form-container',
 	styleUrl: 'ontario-form-container.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-form-container/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-form-container/readme.md
@@ -377,6 +377,14 @@ Once the component package has been installed (see the Ontario Design System Com
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Form Container applies consistent spacing between grouped form elements.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/developer-docs/components/ontario-form-container/
+
 ## Properties
 
 | Property | Attribute | Description                                                                                                              | Type                       | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/ontario-header-menu-tabs.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/ontario-header-menu-tabs.tsx
@@ -8,11 +8,16 @@ import { ConsoleType } from '../../utils/console-message/console-message.enum';
 import translations from '../../translations/global.i18n.json';
 
 /**
- * Ontario Header Menu Tabs Component
+ * Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
  *
- * Provides a tabbed navigation interface for mobile/tablet views.
- * Displays two tabs (Topics and Sign In) with overflow menu content.
- * Manages keyboard navigation, focus trapping, and accessibility.
+ * - Displays two tabs (Topics and Sign In) with overflow menu content.
+ * - Manages keyboard navigation, focus trapping, and accessibility.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+ * - https://designsystem.ontario.ca/components/detail/application-header.html
+ * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
  */
 @Component({
 	tag: 'ontario-header-menu-tabs',

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/readme.md
@@ -4,11 +4,17 @@
 
 ## Overview
 
-Ontario Header Menu Tabs Component
+Ontario Header Menu Tabs provides mobile and tablet tabbed navigation for header menus.
 
-Provides a tabbed navigation interface for mobile/tablet views.
-Displays two tabs (Topics and Sign In) with overflow menu content.
-Manages keyboard navigation, focus trapping, and accessibility.
+- Displays two tabs (Topics and Sign In) with overflow menu content.
+- Manages keyboard navigation, focus trapping, and accessibility.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/ontario-header.html
+- https://designsystem.ontario.ca/components/detail/application-header.html
+- https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-header-menu-tabs/
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.tsx
@@ -6,11 +6,12 @@ import { convertStringToBoolean } from '../../utils/helper/utils';
 import { HeaderKeyboardNavigation } from '../../utils/components/header/header-keyboard-navigation';
 
 /**
- * Overflow Menu Component
+ * Ontario Header Overflow Menu displays overflow navigation links for header contexts.
  *
- * Displays a dropdown menu of links. Can operate in two modes:
+ * It can operate in two modes:
  *
- * ## Standalone Mode
+ * ### Standalone Mode
+ *
  * Used when placed directly in the header (desktop view).
  * - Manages its own open/close state via `menuButtonToggled` event
  * - Automatically focuses first menu item when opened
@@ -18,15 +19,24 @@ import { HeaderKeyboardNavigation } from '../../utils/components/header/header-k
  * - Auto-closes when focus leaves the menu area
  * - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
  *
- * ## Embedded Mode
+ * ### Embedded Mode
+ *
  * Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
  * - Parent component controls open/close state
  * - Parent component manages focus trap
  * - Menu is always visible when parent tab is active
  * - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
  *
- * **Mode Detection**: Auto-detected based on DOM position (no prop needed).
- * Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+ * ### Mode Detection
+ *
+ * - Auto-detected based on DOM position (no prop needed).
+ * - Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+ * - https://designsystem.ontario.ca/components/detail/application-header.html
+ * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
  */
 @Component({
 	tag: 'ontario-header-overflow-menu',

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/readme.md
@@ -83,11 +83,11 @@ If `maxSubheaderLinks` is set within `applicationHeaderInfo` on the `ontario-hea
 
 ## Overview
 
-Overflow Menu Component
+Ontario Header Overflow Menu displays overflow navigation links for header contexts.
 
-Displays a dropdown menu of links. Can operate in two modes:
+It can operate in two modes:
 
-## Standalone Mode
+### Standalone Mode
 
 Used when placed directly in the header (desktop view).
 
@@ -97,7 +97,7 @@ Used when placed directly in the header (desktop view).
 - Auto-closes when focus leaves the menu area
 - **Emits**: `menuClosed` event when menu closes (for cleanup/state sync)
 
-## Embedded Mode
+### Embedded Mode
 
 Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 
@@ -106,8 +106,17 @@ Used when placed inside `ontario-header-menu-tabs` (mobile/tablet view).
 - Menu is always visible when parent tab is active
 - **Emits**: `endOfMenuReached` event when Tab is pressed on last item (for focus looping)
 
-**Mode Detection**: Auto-detected based on DOM position (no prop needed).
-Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+### Mode Detection
+
+- Auto-detected based on DOM position (no prop needed).
+- Checks if ancestor is `ontario-header-menu-tabs` or `.ontario-mobile-menu__panel`.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/ontario-header.html
+- https://designsystem.ontario.ca/components/detail/application-header.html
+- https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-header-overflow-menu/
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.tsx
@@ -30,6 +30,15 @@ import { validateLanguage } from '../../utils/validation/validation-functions';
 import translations from '../../translations/global.i18n.json';
 import config from '../../config.json';
 
+/**
+ * Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/ontario-header.html
+ * - https://designsystem.ontario.ca/components/detail/application-header.html
+ * - https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+ */
 @Component({
 	tag: 'ontario-header',
 	styleUrls: ['ontario-header.scss', 'ontario-application-header.scss', 'service-ontario-header.scss'],

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/readme.md
@@ -510,6 +510,17 @@ Important considerations:
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Header renders Ontario.ca, application, and ServiceOntario header variants.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/ontario-header.html
+- https://designsystem.ontario.ca/components/detail/application-header.html
+- https://designsystem.ontario.ca/components/detail/service-ontario-header.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-header/
+
 ## Properties
 
 | Property                | Attribute                 | Description                                                                                                                                                                                                                                                                                                                                                                                                        | Type                                                          | Default         |

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/ontario-hint-expander.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/ontario-hint-expander.tsx
@@ -7,6 +7,13 @@ import { HintContentType } from '../../utils/common/common.interface';
 import { validatePropExists } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Hint Expander reveals optional supporting guidance on demand.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/hint-text.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+ */
 @Component({
 	tag: 'ontario-hint-expander',
 	styleUrl: 'ontario-hint-expander.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-expander/readme.md
@@ -162,6 +162,15 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Hint Expander reveals optional supporting guidance on demand.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/hint-text.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-hint-expander/
+
 ## Properties
 
 | Property          | Attribute           | Description                                                                                                                                                                                                                                     | Type                              | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-text/ontario-hint-text.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-text/ontario-hint-text.tsx
@@ -7,7 +7,13 @@ import { validatePropExists } from '../../utils/validation/validation-functions'
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
 /**
+ * Ontario Hint Text provides concise supporting instructions for form controls.
+ *
  * Use hint text to help users understand how to complete fields in a form.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/hint-text.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
  *
  * @part hint-text - The container for the hint text content. This part can be used to apply custom styles to the hint text.
  */

--- a/packages/ontario-design-system-component-library/src/components/ontario-hint-text/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-hint-text/readme.md
@@ -139,7 +139,14 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 ## Overview
 
+Ontario Hint Text provides concise supporting instructions for form controls.
+
 Use hint text to help users understand how to complete fields in a form.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/hint-text.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-hint-text/
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
@@ -24,6 +24,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { ErrorMessage } from '../../utils/components/error-message/error-message';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 
+/**
+ * Ontario Input captures single-line text input.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/text-inputs.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+ */
 @Component({
 	tag: 'ontario-input',
 	styleUrl: 'ontario-input.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -381,6 +381,15 @@ The Ontario Input component supports server-side rendering, with a few considera
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Input captures single-line text input.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/text-inputs.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+
 ## Properties
 
 | Property                    | Attribute                     | Description                                                                                                                                                                                                                                                                                                                                 | Type                                                                                                                                        | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/ontario-language-toggle.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/ontario-language-toggle.tsx
@@ -9,6 +9,12 @@ import { validateValueAgainstArray } from '../../utils/validation/validation-fun
 
 import { default as translations } from '../../translations/global.i18n.json';
 
+/**
+ * Ontario Language Toggle switches the interface between supported languages.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+ */
 @Component({
 	tag: 'ontario-language-toggle',
 	styleUrl: 'ontario-language-toggle.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/readme.md
@@ -14,6 +14,14 @@ To ensure the correct language is rendered during SSR, explicitly pass the langu
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Language Toggle switches the interface between supported languages.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/developer-docs/components/ontario-language-toggle/
+
 ## Properties
 
 | Property               | Attribute                | Description                                                                                                                                                                      | Type                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/ontario-loading-indicator.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/ontario-loading-indicator.tsx
@@ -6,6 +6,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 import translations from '../../translations/global.i18n.json';
 
+/**
+ * Ontario Loading Indicator communicates in-progress loading states.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/loading-indicator.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+ */
 @Component({
 	tag: 'ontario-loading-indicator',
 	styleUrl: 'ontario-loading-indicator.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-loading-indicator/readme.md
@@ -147,6 +147,15 @@ The Ontario Loading Indicator component is compatible with Server-Side Rendering
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Loading Indicator communicates in-progress loading states.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/loading-indicator.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-loading-indicator/
+
 ## Properties
 
 | Property            | Attribute             | Description                                                                                                                                                                                                                                                                                                                                                      | Type                        | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.interface.ts
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.interface.ts
@@ -22,13 +22,7 @@ export interface PageAlert {
 	heading: string;
 
 	/**
-	 * The main content for the page alert.
-	 * Use page alerts for high-importance status messages that apply to the whole page (for example success, warning, or error outcomes).
-	 * This can be rendered as either string or HTML content.
-	 *
-	 * For component selection guidance, see:
-	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
-	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * The main content for the page alert. This can be rendered as either string or HTML content.
 	 *
 	 * @example
 	 * <ontario-page-alert content="Please look out for an email confirmation with your receipt and order number.">

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.interface.ts
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.interface.ts
@@ -22,7 +22,13 @@ export interface PageAlert {
 	heading: string;
 
 	/**
-	 * The main content for the page alert. This can be rendered as either string or HTML content.
+	 * The main content for the page alert.
+	 * Use page alerts for high-importance status messages that apply to the whole page (for example success, warning, or error outcomes).
+	 * This can be rendered as either string or HTML content.
+	 *
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
 	 *
 	 * @example
 	 * <ontario-page-alert content="Please look out for an email confirmation with your receipt and order number.">

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
@@ -10,6 +10,7 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
  * For component selection guidance, see:
  * - https://designsystem.ontario.ca/components/detail/page-alerts.html
  * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
  */
 @Component({
 	tag: 'ontario-page-alert',

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
@@ -3,6 +3,14 @@ import { PageAlert, PageAlertType } from './ontario-page-alert.interface';
 import { validateValueAgainstArray } from '../../utils/validation/validation-functions';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Page Alert is used for high-importance status messages that apply to the whole page
+ * (for example informational, warning, success, or error outcomes).
+ *
+ * For component selection guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+ * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+ */
 @Component({
 	tag: 'ontario-page-alert',
 	styleUrl: 'ontario-page-alert.scss',
@@ -30,13 +38,7 @@ export class OntarioPageAlert implements PageAlert {
 	@Prop() heading: string;
 
 	/**
-	 * The main content for the page alert.
-	 * Use page alerts for high-importance status messages that apply to the whole page (for example success, warning, or error outcomes).
-	 * This can be rendered as either string or HTML content.
-	 *
-	 * For component selection guidance, see:
-	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
-	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+	 * The main content for the page alert. This can be rendered as either string or HTML content.
 	 *
 	 * @example
 	 * <ontario-page-alert content="Please look out for an email confirmation with your receipt and order number.">

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.tsx
@@ -30,7 +30,13 @@ export class OntarioPageAlert implements PageAlert {
 	@Prop() heading: string;
 
 	/**
-	 * The main content for the page alert. This can be rendered as either string or HTML content.
+	 * The main content for the page alert.
+	 * Use page alerts for high-importance status messages that apply to the whole page (for example success, warning, or error outcomes).
+	 * This can be rendered as either string or HTML content.
+	 *
+	 * For component selection guidance, see:
+	 * - https://designsystem.ontario.ca/components/detail/page-alerts.html
+	 * - https://designsystem.ontario.ca/components/detail/callouts-asides.html
 	 *
 	 * @example
 	 * <ontario-page-alert content="Please look out for an email confirmation with your receipt and order number.">

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
@@ -168,6 +168,7 @@ For component selection guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/page-alerts.html
 - https://designsystem.ontario.ca/components/detail/callouts-asides.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-page-alert/
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/readme.md
@@ -159,6 +159,16 @@ During SSR, fallback content using `host.textContent` is not reliably available.
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Page Alert is used for high-importance status messages that apply to the whole page
+(for example informational, warning, success, or error outcomes).
+
+For component selection guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/page-alerts.html
+- https://designsystem.ontario.ca/components/detail/callouts-asides.html
+
 ## Properties
 
 | Property  | Attribute | Description                                                                                                                                                                                                   | Type                                                   | Default           |

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
@@ -27,6 +27,13 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 
 import { default as translations } from '../../translations/global.i18n.json';
 
+/**
+ * Ontario Radio Buttons captures a single choice from a defined option set.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+ */
 @Component({
 	tag: 'ontario-radio-buttons',
 	styleUrl: 'ontario-radio-buttons.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -420,6 +420,15 @@ The Ontario Radio Button component supports server-side rendering, with a few co
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Radio Buttons captures a single choice from a defined option set.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/radio-buttons.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                    | Type                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.tsx
@@ -18,6 +18,13 @@ import {
 
 import translations from '../../translations/global.i18n.json';
 
+/**
+ * Ontario Search Box captures and submits search queries.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/search-box.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+ */
 @Component({
 	tag: 'ontario-search-box',
 	styleUrl: 'ontario-search-box.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
@@ -131,6 +131,15 @@ The Ontario Search Box component is compatible with Server-Side Rendering (SSR),
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Search Box captures and submits search queries.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/search-box.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                                                                                                                                                                                                                                                                            | Type                                                            | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/ontario-step-indicator.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/ontario-step-indicator.tsx
@@ -5,6 +5,13 @@ import translations from '../../translations/global.i18n.json';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 
+/**
+ * Ontario Step Indicator communicates progress through multi-step flows.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/step-indicator.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+ */
 @Component({
 	tag: 'ontario-step-indicator',
 	styleUrl: 'ontario-step-indicator.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/readme.md
@@ -409,6 +409,15 @@ The Ontario Step Indicator component is compatible with Server-Side Rendering (S
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Step Indicator communicates progress through multi-step flows.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/step-indicator.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-step-indicator/
+
 ## Properties
 
 | Property             | Attribute             | Description                                                                                                                                                                                                                                                                              | Type                                    | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
@@ -8,6 +8,13 @@ import { ConsoleMessageClass } from '../../utils/console-message/console-message
 import { ConsoleType } from '../../utils/console-message/console-message.enum';
 import { extractValuesByKey, organizeObjectKeys, removeObjectsBySpecificKey } from '../../utils/helper/utils';
 
+/**
+ * Ontario Table presents structured tabular data with accessible semantics.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/tables.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+ */
 @Component({
 	tag: 'ontario-table',
 	styleUrl: 'ontario-table.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/readme.md
@@ -681,6 +681,15 @@ Props such as `tableColumns` and `tableData` are parsed from JSON. To avoid hydr
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Table presents structured tabular data with accessible semantics.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/tables.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-table/
+
 ## Properties
 
 | Property       | Attribute       | Description                                                                                                                                                                                                                                                                                                                                                                         | Type                                             | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-task-list/ontario-task-list.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task-list/ontario-task-list.tsx
@@ -8,6 +8,13 @@ import { validateValueAgainstArray } from '../../utils/validation/validation-fun
 import { TaskStatuses } from '../../utils/common/task-statuses.enum';
 export type TaskListHeadingLevel = 'h1' | Exclude<HeadingLevel, 'h6'>;
 
+/**
+ * Ontario Task List groups and summarizes related tasks.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/task-list.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+ */
 @Component({
 	tag: 'ontario-task-list',
 	styleUrl: 'ontario-task-list.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
@@ -147,6 +147,15 @@ The Ontario Task List component is SSR-compatible but includes some client-only 
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Task List groups and summarizes related tasks.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/task-list.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-task-list/
+
 ## Properties
 
 | Property       | Attribute       | Description                                                                                                                                                                                                   | Type                                   | Default     |

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/ontario-task.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/ontario-task.tsx
@@ -10,6 +10,13 @@ import { HeadingLevel } from '../../utils/common/common.interface';
 import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-events.interface';
 export type TaskHeadingLevel = Extract<HeadingLevel, 'h2' | 'h3' | 'h4'>;
 
+/**
+ * Ontario Task represents an individual task item and status within a task list.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/task-list.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+ */
 @Component({
 	tag: 'ontario-task',
 	styleUrl: 'ontario-task.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
@@ -164,6 +164,15 @@ The Ontario Task component is SSR-compatible and renders predictably during hydr
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Task represents an individual task item and status within a task list.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/task-list.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-task/
+
 ## Properties
 
 | Property         | Attribute         | Description                                                                                                                                                                                                         | Type                                                                                                                                                         | Default                   |

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
@@ -22,6 +22,13 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 import { default as translations } from '../../translations/global.i18n.json';
 import { ErrorMessage } from '../../utils/components/error-message/error-message';
 
+/**
+ * Ontario Textarea captures multi-line text input.
+ *
+ * For component guidance, see:
+ * - https://designsystem.ontario.ca/components/detail/text-areas.html
+ * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+ */
 @Component({
 	tag: 'ontario-textarea',
 	styleUrl: 'ontario-textarea.scss',

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -229,6 +229,15 @@ The Ontario Textarea component supports server-side rendering, with a few consid
 
 <!-- Auto Generated Below -->
 
+## Overview
+
+Ontario Textarea captures multi-line text input.
+
+For component guidance, see:
+
+- https://designsystem.ontario.ca/components/detail/text-areas.html
+- https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                                                                                                                                    | Type                                    | Default     |


### PR DESCRIPTION
## What changed
- added or normalized top-level class JSDoc blocks for the targeted public components in this branch
- updated the guidance section format to keep links easy to scan and consistent
- included component-level links to:
  - core guidance pages (`https://designsystem.ontario.ca/components/detail/...`)
  - developer docs pages (`https://designsystem.ontario.ca/developer-docs/components/<component>/`)
- corrected malformed/duplicated comment blocks introduced during earlier iterations and kept final docs compiler-friendly
- harmonized wording and formatting for this section so guidance is consistent across component READMEs and source docs
