### PR TITLE
DS-2612: harmonize disabled/read-only guidance and error messaging docs

### DIFF
--- a/packages/ontario-design-system-component-library/src/components.d.ts
+++ b/packages/ontario-design-system-component-library/src/components.d.ts
@@ -229,9 +229,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Button triggers actions and supports button or link behavior.
+	 * This component intentionally does not expose a `disabled` prop.
+	 * To support accessible and understandable form completion:
+	 * - keep actions available
+	 * - use validation and error messaging to guide corrections instead of disabling
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioButton {
 		/**
@@ -378,9 +384,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioCheckboxes {
 		/**
@@ -452,9 +464,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dates.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioDateInput {
 		/**
@@ -507,9 +525,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioDropdownList {
 		/**
@@ -2799,9 +2823,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Input captures single-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioInput {
 		/**
@@ -2835,7 +2865,7 @@ export namespace Components {
 		 */
 		enableLiveValidation: boolean;
 		/**
-		 * Set this to display an
+		 * Set this to display an error message.
 		 */
 		errorMessage?: string;
 		/**
@@ -2976,9 +3006,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioRadioButtons {
 		/**
@@ -3036,9 +3072,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Search Box captures and submits search queries.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/search-box.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioSearchBox {
 		/**
@@ -3231,9 +3273,15 @@ export namespace Components {
 	}
 	/**
 	 * Ontario Textarea captures multi-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioTextarea {
 		/**
@@ -3454,9 +3502,15 @@ declare global {
 	};
 	/**
 	 * Ontario Button triggers actions and supports button or link behavior.
+	 * This component intentionally does not expose a `disabled` prop.
+	 * To support accessible and understandable form completion:
+	 * - keep actions available
+	 * - use validation and error messaging to guide corrections instead of disabling
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioButtonElement extends Components.OntarioButton, HTMLStencilElement {}
 	var HTMLOntarioButtonElement: {
@@ -3504,9 +3558,15 @@ declare global {
 	}
 	/**
 	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioCheckboxesElement extends Components.OntarioCheckboxes, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioCheckboxesElementEventMap>(
@@ -3586,9 +3646,15 @@ declare global {
 	}
 	/**
 	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dates.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioDateInputElement extends Components.OntarioDateInput, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioDateInputElementEventMap>(
@@ -3650,9 +3716,15 @@ declare global {
 	}
 	/**
 	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioDropdownListElement extends Components.OntarioDropdownList, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioDropdownListElementEventMap>(
@@ -4636,9 +4708,15 @@ declare global {
 	}
 	/**
 	 * Ontario Input captures single-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioInputElement extends Components.OntarioInput, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioInputElementEventMap>(
@@ -4779,9 +4857,15 @@ declare global {
 	}
 	/**
 	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioRadioButtonsElement extends Components.OntarioRadioButtons, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioRadioButtonsElementEventMap>(
@@ -4844,9 +4928,15 @@ declare global {
 	}
 	/**
 	 * Ontario Search Box captures and submits search queries.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/search-box.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioSearchBoxElement extends Components.OntarioSearchBox, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioSearchBoxElementEventMap>(
@@ -4953,9 +5043,15 @@ declare global {
 	}
 	/**
 	 * Ontario Textarea captures multi-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface HTMLOntarioTextareaElement extends Components.OntarioTextarea, HTMLStencilElement {
 		addEventListener<K extends keyof HTMLOntarioTextareaElementEventMap>(
@@ -5283,9 +5379,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Button triggers actions and supports button or link behavior.
+	 * This component intentionally does not expose a `disabled` prop.
+	 * To support accessible and understandable form completion:
+	 * - keep actions available
+	 * - use validation and error messaging to guide corrections instead of disabling
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioButton {
 		/**
@@ -5432,9 +5534,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Checkboxes collects one or more selections from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioCheckboxes {
 		/**
@@ -5522,9 +5630,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Date Input captures day, month, and year values as a single date field.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dates.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioDateInput {
 		/**
@@ -5607,9 +5721,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Dropdown List presents a selectable list of predefined options.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioDropdownList {
 		/**
@@ -7950,9 +8070,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Input captures single-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioInput {
 		/**
@@ -7986,7 +8112,7 @@ declare namespace LocalJSX {
 		 */
 		enableLiveValidation?: boolean;
 		/**
-		 * Set this to display an
+		 * Set this to display an error message.
 		 */
 		errorMessage?: string;
 		/**
@@ -8155,9 +8281,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Radio Buttons captures a single choice from a defined option set.
+	 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep options and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioRadioButtons {
 		/**
@@ -8231,9 +8363,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Search Box captures and submits search queries.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/search-box.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioSearchBox {
 		/**
@@ -8447,9 +8585,15 @@ declare namespace LocalJSX {
 	}
 	/**
 	 * Ontario Textarea captures multi-line text input.
+	 * This component intentionally does not expose `readOnly` or `disabled` props.
+	 * To support accessible and understandable form completion:
+	 * - keep form fields and submission actions available
+	 * - use validation and error messaging to guide corrections
 	 * For component guidance, see:
 	 * - https://designsystem.ontario.ca/components/detail/text-areas.html
 	 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+	 * Disabled/read-only policy source:
+	 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 	 */
 	interface OntarioTextarea {
 		/**
@@ -8724,9 +8868,15 @@ declare module '@stencil/core' {
 			'ontario-blockquote': LocalJSX.OntarioBlockquote & JSXBase.HTMLAttributes<HTMLOntarioBlockquoteElement>;
 			/**
 			 * Ontario Button triggers actions and supports button or link behavior.
+			 * This component intentionally does not expose a `disabled` prop.
+			 * To support accessible and understandable form completion:
+			 * - keep actions available
+			 * - use validation and error messaging to guide corrections instead of disabling
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/buttons.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-button': LocalJSX.OntarioButton & JSXBase.HTMLAttributes<HTMLOntarioButtonElement>;
 			/**
@@ -8753,9 +8903,15 @@ declare module '@stencil/core' {
 				JSXBase.HTMLAttributes<HTMLOntarioCardCollectionElement>;
 			/**
 			 * Ontario Checkboxes collects one or more selections from a defined option set.
+			 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep options and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/checkboxes.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-checkboxes': LocalJSX.OntarioCheckboxes & JSXBase.HTMLAttributes<HTMLOntarioCheckboxesElement>;
 			/**
@@ -8767,16 +8923,28 @@ declare module '@stencil/core' {
 			'ontario-critical-alert': LocalJSX.OntarioCriticalAlert & JSXBase.HTMLAttributes<HTMLOntarioCriticalAlertElement>;
 			/**
 			 * Ontario Date Input captures day, month, and year values as a single date field.
+			 * This component intentionally does not expose `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep form fields and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/dates.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-date-input': LocalJSX.OntarioDateInput & JSXBase.HTMLAttributes<HTMLOntarioDateInputElement>;
 			/**
 			 * Ontario Dropdown List presents a selectable list of predefined options.
+			 * This component intentionally does not expose `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep form fields and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-dropdown-list': LocalJSX.OntarioDropdownList & JSXBase.HTMLAttributes<HTMLOntarioDropdownListElement>;
 			/**
@@ -9047,9 +9215,15 @@ declare module '@stencil/core' {
 			'ontario-icon-youtube': LocalJSX.OntarioIconYoutube & JSXBase.HTMLAttributes<HTMLOntarioIconYoutubeElement>;
 			/**
 			 * Ontario Input captures single-line text input.
+			 * This component intentionally does not expose `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep form fields and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/text-inputs.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-input': LocalJSX.OntarioInput & JSXBase.HTMLAttributes<HTMLOntarioInputElement>;
 			/**
@@ -9078,16 +9252,28 @@ declare module '@stencil/core' {
 			'ontario-page-alert': LocalJSX.OntarioPageAlert & JSXBase.HTMLAttributes<HTMLOntarioPageAlertElement>;
 			/**
 			 * Ontario Radio Buttons captures a single choice from a defined option set.
+			 * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep options and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-radio-buttons': LocalJSX.OntarioRadioButtons & JSXBase.HTMLAttributes<HTMLOntarioRadioButtonsElement>;
 			/**
 			 * Ontario Search Box captures and submits search queries.
+			 * This component intentionally does not expose `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep form fields and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/search-box.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-search-box': LocalJSX.OntarioSearchBox & JSXBase.HTMLAttributes<HTMLOntarioSearchBoxElement>;
 			/**
@@ -9120,9 +9306,15 @@ declare module '@stencil/core' {
 			'ontario-task-list': LocalJSX.OntarioTaskList & JSXBase.HTMLAttributes<HTMLOntarioTaskListElement>;
 			/**
 			 * Ontario Textarea captures multi-line text input.
+			 * This component intentionally does not expose `readOnly` or `disabled` props.
+			 * To support accessible and understandable form completion:
+			 * - keep form fields and submission actions available
+			 * - use validation and error messaging to guide corrections
 			 * For component guidance, see:
 			 * - https://designsystem.ontario.ca/components/detail/text-areas.html
 			 * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+			 * Disabled/read-only policy source:
+			 * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 			 */
 			'ontario-textarea': LocalJSX.OntarioTextarea & JSXBase.HTMLAttributes<HTMLOntarioTextareaElement>;
 		}

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
@@ -10,9 +10,18 @@ import { isServerSideRendering } from '../../utils/common/environment';
 /**
  * Ontario Button triggers actions and supports button or link behavior.
  *
+ * This component intentionally does not expose a `disabled` prop.
+ *
+ * To support accessible and understandable form completion:
+ * - keep actions available
+ * - use validation and error messaging to guide corrections instead of disabling
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/buttons.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-button',

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
@@ -366,10 +366,21 @@ The Ontario Button component supports server-side rendering, with a few consider
 
 Ontario Button triggers actions and supports button or link behavior.
 
+This component intentionally does not expose a `disabled` prop.
+
+To support accessible and understandable form completion:
+
+- keep actions available
+- use validation and error messaging to guide corrections instead of disabling
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/buttons.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-button/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/readme.md
@@ -10,6 +10,21 @@ Use buttons to help the user carry out an important action such as starting a tr
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/buttons.html) for current documentation guidance.
 
+### Disabled state
+
+This component intentionally does not provide a `disabled` prop.
+
+Disabling action controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+When used in forms, pair button behavior with component-level error handling guidance in related form fields.
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the button component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Please see the [examples](#examples) below for how to configure the component.

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.tsx
@@ -31,9 +31,18 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 /**
  * Ontario Checkboxes collects one or more selections from a defined option set.
  *
+ * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep options and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/checkboxes.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-checkboxes',

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -651,10 +651,21 @@ The Ontario Checkboxes component supports server-side rendering, with a few cons
 
 Ontario Checkboxes collects one or more selections from a defined option set.
 
+This component intentionally does not expose group-level `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep options and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/checkboxes.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-checkboxes/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -500,6 +500,19 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when required selection rules are not met, and keep options available for correction.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-checkboxes
 	id="contact-methods"
@@ -522,6 +535,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 </script>
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
+```
+
 ```tsx
 <OntarioCheckboxes
 	elementId="contact-methods"
@@ -536,6 +554,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-checkboxes
 	[elementId]="'contact-methods'"
@@ -545,6 +568,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 	[options]="contactMethodOptions"
 	[errorMessage]="'Select at least one contact method.'"
 ></ontario-checkboxes>
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Live validation

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -10,6 +10,21 @@ Use checkboxes when you want the user to select one or more options from a list.
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/checkboxes.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide group-level `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the checkbox component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -476,6 +491,69 @@ and emitted. The original `change` event is available via the `detail`
 property on the emitted event.
 
 When using libraries that listen for events, this process may not work with them and a workaround might be required depending on the framework or library in use.
+
+## Error messaging
+
+Use validation and error messaging to help users understand what needs to be corrected.
+
+### Setting an error message
+
+Set `errorMessage` when required selection rules are not met, and keep options available for correction.
+
+```html
+<ontario-checkboxes
+	id="contact-methods"
+	name="contact-methods"
+	caption="How should we contact you?"
+	required
+	options='[
+		{ "elementId": "email", "label": "Email", "value": "email" },
+		{ "elementId": "phone", "label": "Phone", "value": "phone" }
+	]'
+></ontario-checkboxes>
+<script>
+	window.addEventListener('load', () => {
+		const checkboxes = document.getElementById('contact-methods');
+		checkboxes.addEventListener('checkboxOnChange', () => {
+			const checked = checkboxes.querySelectorAll('input[type=\"checkbox\"]:checked').length;
+			checkboxes.errorMessage = checked > 0 ? '' : 'Select at least one contact method.';
+		});
+	});
+</script>
+```
+
+```tsx
+<OntarioCheckboxes
+	elementId="contact-methods"
+	name="contact-methods"
+	caption="How should we contact you?"
+	required
+	options={[
+		{ elementId: 'email', label: 'Email', value: 'email' },
+		{ elementId: 'phone', label: 'Phone', value: 'phone' },
+	]}
+	errorMessage="Select at least one contact method."
+/>
+```
+
+```html
+<ontario-checkboxes
+	[elementId]="'contact-methods'"
+	[name]="'contact-methods'"
+	[caption]="'How should we contact you?'"
+	[required]="true"
+	[options]="contactMethodOptions"
+	[errorMessage]="'Select at least one contact method.'"
+></ontario-checkboxes>
+```
+
+### Live validation
+
+Keep the control available and validate selections on interaction (for example, on change, blur, or submit). When validation fails, set a contextual error message that explains how to fix the issue.
+
+See the Ontario Design System guidance:
+
+- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/readme.md
@@ -500,6 +500,14 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when required selection rules are not met, and keep options available for correction.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -578,10 +586,6 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 ### Live validation
 
 Keep the control available and validate selections on interaction (for example, on change, blur, or submit). When validation fails, set a contextual error message that explains how to fix the issue.
-
-See the Ontario Design System guidance:
-
-- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.tsx
@@ -22,9 +22,18 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 /**
  * Ontario Date Input captures day, month, and year values as a single date field.
  *
+ * This component intentionally does not expose `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep form fields and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/dates.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-date-input',

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -398,6 +398,19 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and surface message text through `errorMessage`.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-date-input id="date-of-birth" caption="Date of birth" required></ontario-date-input>
 <script>
@@ -414,6 +427,11 @@ Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and 
 		};
 	});
 </script>
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
 ```
 
 ```tsx
@@ -433,6 +451,11 @@ Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and 
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-date-input
 	[elementId]="'date-of-birth'"
@@ -440,6 +463,11 @@ Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and 
 	[required]="true"
 	[dateValidator]="validateDateOfBirth"
 ></ontario-date-input>
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Live validation

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -535,10 +535,21 @@ The Ontario Date Input component is compatible with server-side rendering, with 
 
 Ontario Date Input captures day, month, and year values as a single date field.
 
+This component intentionally does not expose `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep form fields and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/dates.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-date-input/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -10,6 +10,21 @@ Use this component for user-friendly date input and display.
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/dates.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the date input component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for the date input properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -374,6 +389,66 @@ The same aggregate value is also included in `event.detail.value` for consumers 
 The field-level `inputOnInput` and `inputOnChange` custom events remain available when you need to know which sub-field changed.
 
 When using libraries that listen for events, this process may not work with them and a workaround might be required depending on the framework or library in use.
+
+## Error messaging
+
+Use validation and error messaging to help users understand what needs to be corrected.
+
+### Setting an error message
+
+Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and surface message text through `errorMessage`.
+
+```html
+<ontario-date-input id="date-of-birth" caption="Date of birth" required></ontario-date-input>
+<script>
+	window.addEventListener('load', () => {
+		const dateInput = document.getElementById('date-of-birth');
+		dateInput.dateValidator = (day, month, year) => {
+			const allPartsPresent = !!day && !!month && !!year;
+			return {
+				errorMessage: allPartsPresent ? '' : 'Enter a complete date of birth.',
+				dayInvalid: !day,
+				monthInvalid: !month,
+				yearInvalid: !year,
+			};
+		};
+	});
+</script>
+```
+
+```tsx
+<OntarioDateInput
+	elementId="date-of-birth"
+	caption="Date of birth"
+	required
+	dateValidator={(day, month, year) => {
+		const allPartsPresent = !!day && !!month && !!year;
+		return {
+			errorMessage: allPartsPresent ? '' : 'Enter a complete date of birth.',
+			dayInvalid: !day,
+			monthInvalid: !month,
+			yearInvalid: !year,
+		};
+	}}
+/>
+```
+
+```html
+<ontario-date-input
+	[elementId]="'date-of-birth'"
+	[caption]="'Date of birth'"
+	[required]="true"
+	[dateValidator]="validateDateOfBirth"
+></ontario-date-input>
+```
+
+### Live validation
+
+Keep the control available and validate date fields on interaction (for example, on blur or submit). Return contextual error guidance from `dateValidator` so users can correct incomplete or invalid values.
+
+See the Ontario Design System guidance:
+
+- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/readme.md
@@ -398,6 +398,14 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and surface message text through `errorMessage`.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -473,10 +481,6 @@ Use `dateValidator` to return contextual errors (`DateValidatorReturnType`) and 
 ### Live validation
 
 Keep the control available and validate date fields on interaction (for example, on blur or submit). Return contextual error guidance from `dateValidator` so users can correct incomplete or invalid values.
-
-See the Ontario Design System guidance:
-
-- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.tsx
@@ -28,9 +28,18 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 /**
  * Ontario Dropdown List presents a selectable list of predefined options.
  *
+ * This component intentionally does not expose `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep form fields and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-dropdown-list',

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -679,10 +679,21 @@ The Ontario Dropdown List component supports server-side rendering, with a few c
 
 Ontario Dropdown List presents a selectable list of predefined options.
 
+This component intentionally does not expose `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep form fields and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/dropdown-lists.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-dropdown-list/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -10,6 +10,21 @@ Only use a dropdown (select) list if you cannot use other form components to cap
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/dropdown-lists.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the dropdown list component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for dropdown list properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -508,6 +523,68 @@ internal control. The current selection is available through
 `event.detail.value`.
 
 When using libraries that listen for events, this process may not work with them and a workaround might be required depending on the framework or library in use.
+
+## Error messaging
+
+Use validation and error messaging to help users understand what needs to be corrected.
+
+### Setting an error message
+
+Set `errorMessage` when selection is missing or invalid, and keep the list enabled so users can correct their choice.
+
+```html
+<ontario-dropdown-list
+	id="service-selection"
+	name="service-selection"
+	caption="Select a service"
+	required
+	options='[
+		{ "label": "Health card", "value": "health-card" },
+		{ "label": "Driver licence", "value": "driver-licence" }
+	]'
+></ontario-dropdown-list>
+<script>
+	window.addEventListener('load', () => {
+		const dropdown = document.getElementById('service-selection');
+		dropdown.addEventListener('inputOnBlur', () => {
+			dropdown.errorMessage = dropdown.value ? '' : 'Select a service to continue.';
+		});
+	});
+</script>
+```
+
+```tsx
+<OntarioDropdownList
+	elementId="service-selection"
+	name="service-selection"
+	caption="Select a service"
+	required
+	options={[
+		{ label: 'Health card', value: 'health-card' },
+		{ label: 'Driver licence', value: 'driver-licence' },
+	]}
+	errorMessage="Select a service to continue."
+/>
+```
+
+```html
+<ontario-dropdown-list
+	[elementId]="'service-selection'"
+	[name]="'service-selection'"
+	[caption]="'Select a service'"
+	[required]="true"
+	[options]="serviceOptions"
+	[errorMessage]="'Select a service to continue.'"
+></ontario-dropdown-list>
+```
+
+### Live validation
+
+Keep the control available and validate selection on interaction (for example, on blur or submit). When validation fails, set a contextual error message that explains how to fix the issue.
+
+See the Ontario Design System guidance:
+
+- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -532,6 +532,19 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when selection is missing or invalid, and keep the list enabled so users can correct their choice.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-dropdown-list
 	id="service-selection"
@@ -553,6 +566,11 @@ Set `errorMessage` when selection is missing or invalid, and keep the list enabl
 </script>
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
+```
+
 ```tsx
 <OntarioDropdownList
 	elementId="service-selection"
@@ -567,6 +585,11 @@ Set `errorMessage` when selection is missing or invalid, and keep the list enabl
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-dropdown-list
 	[elementId]="'service-selection'"
@@ -576,6 +599,11 @@ Set `errorMessage` when selection is missing or invalid, and keep the list enabl
 	[options]="serviceOptions"
 	[errorMessage]="'Select a service to continue.'"
 ></ontario-dropdown-list>
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Live validation

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/readme.md
@@ -532,6 +532,14 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when selection is missing or invalid, and keep the list enabled so users can correct their choice.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -609,10 +617,6 @@ Set `errorMessage` when selection is missing or invalid, and keep the list enabl
 ### Live validation
 
 Keep the control available and validate selection on interaction (for example, on blur or submit). When validation fails, set a contextual error message that explains how to fix the issue.
-
-See the Ontario Design System guidance:
-
-- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
@@ -27,9 +27,18 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 /**
  * Ontario Input captures single-line text input.
  *
+ * This component intentionally does not expose `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep form fields and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/text-inputs.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-input',
@@ -121,7 +130,7 @@ export class OntarioInput implements TextInput {
 	@Prop({ mutable: true }) value?: string;
 
 	/**
-	 * Set this to display an
+	 * Set this to display an error message.
 	 */
 	@Prop({ mutable: true }) errorMessage?: string;
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -235,6 +235,14 @@ When using libraries that listen for events, this process may not work with them
 
 An error message can be displayed on an input by setting the `errorMessage` property. This will display a message to the user along with broadcasting an event, called `inputErrorOccurred`, that can be listened for by other components or custom event handlers.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -406,12 +414,6 @@ For example,
 		requiredValidationMessage="Enter your first name">
 	</OntarioInput>
 </div>
-
-### Learn more
-
-Error messaging best practices are based off the Ontario Design System [Error messaging guidance](https://designsystem.ontario.ca/components/detail/error-messaging.html).
-
-Visit the [Live validation](https://designsystem.ontario.ca/components/detail/error-messaging.html) guidance page for more information about live validation.
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -235,6 +235,19 @@ When using libraries that listen for events, this process may not work with them
 
 An error message can be displayed on an input by setting the `errorMessage` property. This will display a message to the user along with broadcasting an event, called `inputErrorOccurred`, that can be listened for by other components or custom event handlers.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-input id="input-1" name="input-1" caption="What is your name?" required></ontario-input>
 <script>
@@ -249,7 +262,10 @@ An error message can be displayed on an input by setting the `errorMessage` prop
 </script>
 ```
 
-_Note: to test the above code sample either set an `errorMessage` on `input-1` or add the `enable-live-validation` attribute._
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
+```
 
 ```tsx
 <OntarioInput
@@ -261,6 +277,11 @@ _Note: to test the above code sample either set an `errorMessage` on `input-1` o
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-input
 	[elementId]="'input-1'"
@@ -270,6 +291,13 @@ _Note: to test the above code sample either set an `errorMessage` on `input-1` o
 	[errorMessage]="'Enter your first name'"
 ></ontario-input>
 ```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+_Note: to test the above code sample either set an `errorMessage` on `input-1` or add the `enable-live-validation` attribute._
 
 ### Live validation
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -471,10 +471,21 @@ The Ontario Input component supports server-side rendering, with a few considera
 
 Ontario Input captures single-line text input.
 
+This component intentionally does not expose `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep form fields and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/text-inputs.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-input/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 
@@ -487,7 +498,7 @@ For component guidance, see:
 | `customOnInput`             | `custom-on-input`             | Used to add a custom function to the input onInput event.                                                                                                                                                                                                                                                                                   | `((event: Event) => void) \| undefined`                                                                                                     | `undefined` |
 | `elementId`                 | `element-id`                  | The unique identifier of the input. This is optional - if no ID is passed, one will be generated.                                                                                                                                                                                                                                           | `string \| undefined`                                                                                                                       | `undefined` |
 | `enableLiveValidation`      | `enable-live-validation`      | Enable live validation on the input. Custom live validation can be performed using an `inputValidator` validation function. It will also validate the `required` state if no errors are returned from the `inputValidator`. Please set a `requiredValidationMessage` to report concisely to the end user what they are required to set.     | `boolean`                                                                                                                                   | `false`     |
-| `errorMessage`              | `error-message`               | Set this to display an                                                                                                                                                                                                                                                                                                                      | `string \| undefined`                                                                                                                       | `undefined` |
+| `errorMessage`              | `error-message`               | Set this to display an error message.                                                                                                                                                                                                                                                                                                       | `string \| undefined`                                                                                                                       | `undefined` |
 | `hintExpander`              | `hint-expander`               | Used to include the ontario-hint-expander component for the input component. This is passed in as an object with key-value pairs. This is optional.                                                                                                                                                                                         | `HintExpander \| string \| undefined`                                                                                                       | `undefined` |
 | `hintText`                  | `hint-text`                   | Used to include the ontario-hint-text component for the input. This is optional.                                                                                                                                                                                                                                                            | `Hint \| string \| undefined`                                                                                                               | `undefined` |
 | `inputValidator`            | `input-validator`             | Validate the validity of the input value `onBlur`. This `async` function should return a result to trigger an error message. Returning `undefined` or `null` will clear it.                                                                                                                                                                 | `((value?: string \| undefined) => Promise<{ errorMessage?: string \| undefined; } \| null \| undefined>) \| undefined`                     | `undefined` |

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/readme.md
@@ -10,6 +10,21 @@ Use a text input when you want the user to enter no more than a single line of i
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/text-inputs.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the input component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -236,7 +251,27 @@ An error message can be displayed on an input by setting the `errorMessage` prop
 
 _Note: to test the above code sample either set an `errorMessage` on `input-1` or add the `enable-live-validation` attribute._
 
-### Input live validation
+```tsx
+<OntarioInput
+	elementId="input-1"
+	name="input-1"
+	caption="What is your name?"
+	required
+	errorMessage="Enter your first name"
+/>
+```
+
+```html
+<ontario-input
+	[elementId]="'input-1'"
+	[name]="'input-1'"
+	[caption]="'What is your name?'"
+	[required]="true"
+	[errorMessage]="'Enter your first name'"
+></ontario-input>
+```
+
+### Live validation
 
 By setting the `enableLiveValidation` property the value of an input can be validated by using the custom `inputValidator` function. This function notifies the component if there is an error based on the custom logic that fits your application. On the `blur` event of the component, it will pass over the `value` of the input and if an `errorMessage` is returned it will instruct the component to display it. To clear the error message displayed return `undefined` or `null`.
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.tsx
@@ -30,9 +30,18 @@ import { default as translations } from '../../translations/global.i18n.json';
 /**
  * Ontario Radio Buttons captures a single choice from a defined option set.
  *
+ * This component intentionally does not expose group-level `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep options and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/radio-buttons.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-radio-buttons',

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -534,6 +534,19 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when required selection rules are not met, and keep options available for correction.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-radio-buttons
 	id="contact-preference"
@@ -556,6 +569,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 </script>
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
+```
+
 ```tsx
 <OntarioRadioButtons
 	elementId="contact-preference"
@@ -570,6 +588,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-radio-buttons
 	[elementId]="'contact-preference'"
@@ -579,6 +602,11 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 	[options]="contactPreferenceOptions"
 	[errorMessage]="'Select one option to continue.'"
 ></ontario-radio-buttons>
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Live validation

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -676,10 +676,21 @@ The Ontario Radio Buttons component supports server-side rendering, with a few c
 
 Ontario Radio Buttons captures a single choice from a defined option set.
 
+This component intentionally does not expose group-level `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep options and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/radio-buttons.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-radio-buttons/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -10,6 +10,21 @@ Use radio buttons when you want the user to select only one option from a list.
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/radio-buttons.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide group-level `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the radio button component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -510,6 +525,69 @@ control. The current selection is available through `event.target.value`, and a
 convenience copy is also included in `event.detail.value`.
 
 When using libraries that listen for events, this process may not work with them and a workaround might be required depending on the framework or library in use.
+
+## Error messaging
+
+Use validation and error messaging to help users understand what needs to be corrected.
+
+### Setting an error message
+
+Set `errorMessage` when required selection rules are not met, and keep options available for correction.
+
+```html
+<ontario-radio-buttons
+	id="contact-preference"
+	name="contact-preference"
+	caption="Preferred contact method"
+	required
+	options='[
+		{ "elementId": "pref-email", "label": "Email", "value": "email" },
+		{ "elementId": "pref-phone", "label": "Phone", "value": "phone" }
+	]'
+></ontario-radio-buttons>
+<script>
+	window.addEventListener('load', () => {
+		const radios = document.getElementById('contact-preference');
+		radios.addEventListener('radioOnBlur', () => {
+			const selected = radios.querySelector('input[type=\"radio\"]:checked');
+			radios.errorMessage = selected ? '' : 'Select one option to continue.';
+		});
+	});
+</script>
+```
+
+```tsx
+<OntarioRadioButtons
+	elementId="contact-preference"
+	name="contact-preference"
+	caption="Preferred contact method"
+	required
+	options={[
+		{ elementId: 'pref-email', label: 'Email', value: 'email' },
+		{ elementId: 'pref-phone', label: 'Phone', value: 'phone' },
+	]}
+	errorMessage="Select one option to continue."
+/>
+```
+
+```html
+<ontario-radio-buttons
+	[elementId]="'contact-preference'"
+	[name]="'contact-preference'"
+	[caption]="'Preferred contact method'"
+	[required]="true"
+	[options]="contactPreferenceOptions"
+	[errorMessage]="'Select one option to continue.'"
+></ontario-radio-buttons>
+```
+
+### Live validation
+
+Keep the control available and validate selections on interaction (for example, on change, blur, or submit). When validation fails, set a contextual error message that explains how to fix the issue.
+
+See the Ontario Design System guidance:
+
+- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/readme.md
@@ -534,6 +534,14 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set `errorMessage` when required selection rules are not met, and keep options available for correction.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -612,10 +620,6 @@ Set `errorMessage` when required selection rules are not met, and keep options a
 ### Live validation
 
 Keep the control available and validate selections on interaction (for example, on change, blur, or submit). When validation fails, set a contextual error message that explains how to fix the issue.
-
-See the Ontario Design System guidance:
-
-- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.tsx
@@ -21,9 +21,18 @@ import translations from '../../translations/global.i18n.json';
 /**
  * Ontario Search Box captures and submits search queries.
  *
+ * This component intentionally does not expose `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep form fields and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/search-box.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-search-box',

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
@@ -152,10 +152,21 @@ The Ontario Search Box component supports server-side rendering, with a few cons
 
 Ontario Search Box captures and submits search queries.
 
+This component intentionally does not expose `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep form fields and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/search-box.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-search-box/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/readme.md
@@ -10,6 +10,21 @@ Use a search box to let users complete keyword-based searches.
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/search-box.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- validate search requirements in your integration logic and provide contextual feedback
+
+For field-level validation patterns, see the input component [Error messaging](../ontario-input/#error-messaging) guidance.
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the search box component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.tsx
@@ -25,9 +25,18 @@ import { ErrorMessage } from '../../utils/components/error-message/error-message
 /**
  * Ontario Textarea captures multi-line text input.
  *
+ * This component intentionally does not expose `readOnly` or `disabled` props.
+ *
+ * To support accessible and understandable form completion:
+ * - keep form fields and submission actions available
+ * - use validation and error messaging to guide corrections
+ *
  * For component guidance, see:
  * - https://designsystem.ontario.ca/components/detail/text-areas.html
  * - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+ *
+ * Disabled/read-only policy source:
+ * - https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
  */
 @Component({
 	tag: 'ontario-textarea',

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -10,6 +10,21 @@ Use a text area when you want the user to enter **more than** a single line of i
 
 Please refer to the [Ontario Design System](https://designsystem.ontario.ca/components/detail/text-areas.html) for current documentation guidance.
 
+### Disabled and read-only states
+
+This component intentionally does not provide `readOnly` or `disabled` props.
+
+Disabling form controls can create accessibility and usability barriers, and often does not explain what the user needs to fix.
+
+Instead:
+
+- keep controls and submission actions available
+- use validation and error messaging to clearly identify missing or invalid input
+
+For implementation examples, see [Error messaging](#error-messaging).
+
+Source: https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
+
 ## Configuration
 
 Once the component package has been installed (see Ontario Design System Component Library for installation instructions), the textarea component can be added directly into the project's code, and can be customized by updating the properties outlined [here](#properties). Additional information on custom types for header properties are outlined [here](#custom-property-types). Please see the [examples](#examples) below for how to configure the component.
@@ -195,6 +210,54 @@ document.querySelector('ontario-textarea').addEventListener('change', (event) =>
 ```
 
 When using libraries that listen for events, this process may not work with them and a workaround might be required depending on the framework or library in use.
+
+## Error messaging
+
+Use validation and error messaging to help users understand what needs to be corrected.
+
+### Setting an error message
+
+Set the `errorMessage` property on `ontario-textarea` to display an error state and message. You can also listen for `inputErrorOccurred` to react to error updates in application code.
+
+```html
+<ontario-textarea id="comments" name="comments" caption="Comments" required></ontario-textarea>
+<script>
+	window.addEventListener('load', () => {
+		const textarea = document.getElementById('comments');
+		textarea.addEventListener('inputOnBlur', () => {
+			textarea.errorMessage = textarea.value?.trim() ? '' : 'Enter your comments before continuing.';
+		});
+	});
+</script>
+```
+
+```tsx
+<OntarioTextarea
+	elementId="comments"
+	name="comments"
+	caption="Comments"
+	required
+	errorMessage="Enter your comments before continuing."
+/>
+```
+
+```html
+<ontario-textarea
+	[elementId]="'comments'"
+	[name]="'comments'"
+	[caption]="'Comments'"
+	[required]="true"
+	[errorMessage]="'Enter your comments before continuing.'"
+></ontario-textarea>
+```
+
+### Live validation
+
+Keep the control available and validate content on interaction (for example, on blur or submit). When validation fails, set a contextual error message that explains how to fix the issue.
+
+See the Ontario Design System guidance:
+
+- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -219,6 +219,14 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set the `errorMessage` property on `ontario-textarea` to display an error state and message. You can also listen for `inputErrorOccurred` to react to error updates in application code.
 
+### Static vs live validation
+
+Use a static `errorMessage` when validation happens on submit (for example, after a form post or submit handler check).
+
+Use live validation when you want real-time feedback as users interact (for example, on change or blur).
+
+For more guidance, visit the [Error messaging guidance page](https://designsystem.ontario.ca/components/detail/error-messaging.html).
+
 ```mdx-code-block
 <Tabs
 	defaultValue="html"
@@ -282,10 +290,6 @@ Set the `errorMessage` property on `ontario-textarea` to display an error state 
 ### Live validation
 
 Keep the control available and validate content on interaction (for example, on blur or submit). When validation fails, set a contextual error message that explains how to fix the issue.
-
-See the Ontario Design System guidance:
-
-- https://designsystem.ontario.ca/components/detail/error-messaging.html
 
 ## Custom property types
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -344,10 +344,21 @@ The Ontario Textarea component supports server-side rendering, with a few consid
 
 Ontario Textarea captures multi-line text input.
 
+This component intentionally does not expose `readOnly` or `disabled` props.
+
+To support accessible and understandable form completion:
+
+- keep form fields and submission actions available
+- use validation and error messaging to guide corrections
+
 For component guidance, see:
 
 - https://designsystem.ontario.ca/components/detail/text-areas.html
 - https://designsystem.ontario.ca/developer-docs/components/ontario-textarea/
+
+Disabled/read-only policy source:
+
+- https://designsystem.ontario.ca/components/detail/buttons.html#disabled-buttons
 
 ## Properties
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/readme.md
@@ -219,6 +219,19 @@ Use validation and error messaging to help users understand what needs to be cor
 
 Set the `errorMessage` property on `ontario-textarea` to display an error state and message. You can also listen for `inputErrorOccurred` to react to error updates in application code.
 
+```mdx-code-block
+<Tabs
+	defaultValue="html"
+	values={[
+		{label: 'HTML', value: 'html'},
+		{label: 'React', value: 'react'},
+		{label: 'Angular', value: 'angular'},
+	]}
+	groupId="framework"
+	queryString="framework">
+<TabItem value="html">
+```
+
 ```html
 <ontario-textarea id="comments" name="comments" caption="Comments" required></ontario-textarea>
 <script>
@@ -231,6 +244,11 @@ Set the `errorMessage` property on `ontario-textarea` to display an error state 
 </script>
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="react">
+```
+
 ```tsx
 <OntarioTextarea
 	elementId="comments"
@@ -241,6 +259,11 @@ Set the `errorMessage` property on `ontario-textarea` to display an error state 
 />
 ```
 
+```mdx-code-block
+</TabItem>
+<TabItem value="angular">
+```
+
 ```html
 <ontario-textarea
 	[elementId]="'comments'"
@@ -249,6 +272,11 @@ Set the `errorMessage` property on `ontario-textarea` to display an error state 
 	[required]="true"
 	[errorMessage]="'Enter your comments before continuing.'"
 ></ontario-textarea>
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
 ```
 
 ### Live validation


### PR DESCRIPTION
## Summary
- harmonised class-level component JSDocs so Stencil auto-docs generate consistent top-level guidance
- aligned disabled/read-only guidance across relevant components, including form controls plus `ontario-button` and `ontario-search-box`
- standardised Error messaging sections for form components with Docusaurus framework tabs (HTML, React, Angular)
- added concise static-vs-live validation guidance and linked to the canonical Ontario guidance page in each relevant component
- removed duplicate error-guidance references so each affected README points to the canonical guidance once
- regenerated and committed documentation artefacts so generated outputs are in sync (`components.d.ts` and impacted component README files)

## Scope highlights
- class-level JSDoc updates for targeted components
- README guidance updates for:
  - `ontario-input`
  - `ontario-textarea`
  - `ontario-date-input`
  - `ontario-dropdown-list`
  - `ontario-checkboxes`
  - `ontario-radio-buttons`
  - `ontario-button`
  - `ontario-search-box`

## Merge order
- merge this PR after its ancestor PR #217
