### PR TITLE
DS-2635: add package-level llms guidance and cross-package discoverability

### DIFF
--- a/packages/ontario-design-system-complete-styles/README.md
+++ b/packages/ontario-design-system-complete-styles/README.md
@@ -12,6 +12,14 @@ The Ontario Design System complete styles package can be used in place of the On
 
 The complete styles package includes the [Ontario Design System global styles](https://www.npmjs.com/package/@ongov/ontario-design-system-global-styles), along with component styles, assets, fonts, favicons and scripts that will provide all the necessary styles and functionality of the Ontario Design System.
 
+### AI guidance file
+
+This package ships a package-level `llms.txt` file with AI-oriented integration guidance.
+Related package guidance is also available in:
+
+- `@ongov/ontario-design-system-global-styles`
+- `@ongov/ontario-design-system-component-library`
+
 ## Installation and usage
 
 To install the Ontario Design System complete styles package, run the following command:

--- a/packages/ontario-design-system-complete-styles/llms.txt
+++ b/packages/ontario-design-system-complete-styles/llms.txt
@@ -1,0 +1,16 @@
+# Ontario Design System Complete Styles
+
+Use this package for the complete standalone ODS style bundle.
+
+## Integration Rules
+- Consume compiled and SCSS outputs from documented export paths.
+- Prefer package defaults before adding custom style pipelines.
+- Keep usage aligned with ODS accessibility and component guidance.
+
+## Guidance Links
+- https://designsystem.ontario.ca/
+- https://designsystem.ontario.ca/components/
+
+## Related Packages
+- @ongov/ontario-design-system-global-styles
+- @ongov/ontario-design-system-component-library

--- a/packages/ontario-design-system-complete-styles/package.json
+++ b/packages/ontario-design-system-complete-styles/package.json
@@ -9,7 +9,8 @@
 	"files": [
 		"dist/",
 		"package.json",
-		"README.md"
+		"README.md",
+		"llms.txt"
 	],
 	"scripts": {
 		"build": "gulp deploy && pnpm run docs:copy:readme",

--- a/packages/ontario-design-system-component-library-angular/README.md
+++ b/packages/ontario-design-system-component-library-angular/README.md
@@ -11,6 +11,14 @@
 
 This library is built using [`@stencil/angular-output-target`](https://www.npmjs.com/package/@stencil/angular-output-target) and supports Angular versions 20+. It is based off the [Ontario Design System Component Library](https://www.npmjs.com/package/@ongov/ontario-design-system-component-library) built using [Stencil](https://stenciljs.com/). For more information, [find it on NPM](https://www.npmjs.com/package/@ongov/ontario-design-system-component-library-angular).
 
+### AI guidance file
+
+This package ships a package-level `llms.txt` file with AI-oriented integration guidance.
+Related package guidance is also available in:
+
+- `@ongov/ontario-design-system-component-library`
+- `@ongov/ontario-design-system-global-styles`
+
 ## Installation and usage
 
 To find documentation on individual web components in this component library, please download and refer to our [component documentation](https://designsystem.ontario.ca/docs/documentation/for-developers/web-components.html#component-documentation).

--- a/packages/ontario-design-system-component-library-angular/llms.txt
+++ b/packages/ontario-design-system-component-library-angular/llms.txt
@@ -1,0 +1,20 @@
+# Ontario Design System Angular Wrappers
+
+Use this package for Angular bindings around ODS web components.
+
+## Integration Rules
+- Consume the Angular component library outputs as documented.
+- Use package-provided asset and styles paths.
+- Prefer documented Angular wrapper patterns over custom shims.
+
+## Angular Notes
+- Follow Angular integration guidance for wrapper imports and asset wiring.
+- Keep framework setup consistent with package README instructions.
+
+## Guidance Links
+- https://designsystem.ontario.ca/developer-docs/
+- https://designsystem.ontario.ca/components/
+
+## Related Packages
+- @ongov/ontario-design-system-component-library
+- @ongov/ontario-design-system-global-styles

--- a/packages/ontario-design-system-component-library-angular/package.json
+++ b/packages/ontario-design-system-component-library-angular/package.json
@@ -43,7 +43,8 @@
 		"dist/",
 		"projects/component-library/src",
 		"package.json",
-		"README.md"
+		"README.md",
+		"llms.txt"
 	],
 	"dependencies": {
 		"@ongov/ontario-design-system-component-library": "workspace:*",

--- a/packages/ontario-design-system-component-library-react/README.md
+++ b/packages/ontario-design-system-component-library-react/README.md
@@ -18,6 +18,14 @@ This package targets React 19 and ships bindings that align with React 19's JSX/
 
 For Next.js-specific setup guidance, including SSR configuration and asset handling, use the official [Next.js integration guide](https://designsystem.ontario.ca/developer-docs/framework-integrations/next-js-ssr/).
 
+### AI guidance file
+
+This package ships a package-level `llms.txt` file with AI-oriented integration guidance.
+Related package guidance is also available in:
+
+- `@ongov/ontario-design-system-component-library`
+- `@ongov/ontario-design-system-global-styles`
+
 ## Installation and usage
 
 To find documentation on individual web components in this component library, please download and refer to our [component documentation](https://designsystem.ontario.ca/docs/documentation/for-developers/web-components.html#component-documentation).

--- a/packages/ontario-design-system-component-library-react/llms.txt
+++ b/packages/ontario-design-system-component-library-react/llms.txt
@@ -1,0 +1,20 @@
+# Ontario Design System React Wrappers
+
+Use this package for React bindings around ODS web components.
+
+## Integration Rules
+- Import components from this package for React applications.
+- Keep usage aligned with documented SSR patterns.
+- Use package-exported styles and assets.
+
+## Next.js Notes
+- Follow ODS Next.js setup guidance for React wrapper usage.
+- Keep server and client component boundaries explicit.
+
+## Guidance Links
+- https://designsystem.ontario.ca/developer-docs/
+- https://designsystem.ontario.ca/components/
+
+## Related Packages
+- @ongov/ontario-design-system-component-library
+- @ongov/ontario-design-system-global-styles

--- a/packages/ontario-design-system-component-library-react/package.json
+++ b/packages/ontario-design-system-component-library-react/package.json
@@ -40,7 +40,8 @@
 		"dist/",
 		"src/",
 		"package.json",
-		"README.md"
+		"README.md",
+		"llms.txt"
 	],
 	"scripts": {
 		"build": "pnpm run clean && pnpm run compile && pnpm run docs:copy:readme && pnpm run docs:copy:docs",

--- a/packages/ontario-design-system-component-library/llms.txt
+++ b/packages/ontario-design-system-component-library/llms.txt
@@ -1,0 +1,21 @@
+# Ontario Design System Web Components
+
+Use this package for framework-agnostic Ontario Design System web components.
+
+## Integration Rules
+- Register and hydrate components using the package loader and hydrate entry points.
+- Prefer documented component APIs and events.
+- Do not depend on internal DOM structure for behavior.
+
+## Next.js Notes
+- Follow official ODS Next.js integration guidance before custom SSR setup.
+- Keep client boundaries explicit for interactive components.
+
+## Guidance Links
+- https://designsystem.ontario.ca/
+- https://designsystem.ontario.ca/developer-docs/
+
+## Related Packages
+- @ongov/ontario-design-system-component-library-react
+- @ongov/ontario-design-system-component-library-angular
+- @ongov/ontario-design-system-global-styles

--- a/packages/ontario-design-system-component-library/package.json
+++ b/packages/ontario-design-system-component-library/package.json
@@ -18,7 +18,8 @@
 		"www/",
 		"LICENSE",
 		"package.json",
-		"readme.md"
+		"readme.md",
+		"llms.txt"
 	],
 	"exports": {
 		".": {

--- a/packages/ontario-design-system-component-library/readme.md
+++ b/packages/ontario-design-system-component-library/readme.md
@@ -28,6 +28,15 @@ Use this package if you are working with plain HTML or any framework/tooling tha
 - [Ontario Design System Angular component library](https://www.npmjs.com/package/@ongov/ontario-design-system-component-library-angular)
 - [Ontario Design System React component library](https://www.npmjs.com/package/@ongov/ontario-design-system-component-library-react)
 
+### AI guidance file
+
+This package ships a package-level `llms.txt` file with AI-oriented integration guidance.
+Related package guidance is also available in:
+
+- `@ongov/ontario-design-system-component-library-react`
+- `@ongov/ontario-design-system-component-library-angular`
+- `@ongov/ontario-design-system-global-styles`
+
 ## Installation and usage
 
 There are two ways to install the Ontario Design System component library package into your project: through [npm](#installing-the-npm-package) or through a [CDN](#cdn).

--- a/packages/ontario-design-system-global-styles/README.md
+++ b/packages/ontario-design-system-global-styles/README.md
@@ -14,6 +14,16 @@ The Ontario Design System global styles package is required to use the Ontario D
 
 It includes the Ontario Design System global styles that are used for more generic elements and layouts, as well as font assets and favicons.
 
+### AI guidance file
+
+This package ships a package-level `llms.txt` file with AI-oriented integration guidance.
+Related package guidance is also available in:
+
+- `@ongov/ontario-design-system-component-library`
+- `@ongov/ontario-design-system-component-library-react`
+- `@ongov/ontario-design-system-component-library-angular`
+- `@ongov/ontario-design-system-complete-styles`
+
 ## Installation and usage
 
 To install the Ontario Design System global styles package, run the following command:

--- a/packages/ontario-design-system-global-styles/llms.txt
+++ b/packages/ontario-design-system-global-styles/llms.txt
@@ -1,0 +1,18 @@
+# Ontario Design System Global Styles
+
+Use this package for ODS global CSS and SCSS foundations.
+
+## Integration Rules
+- Prefer package export paths for CSS and SCSS consumption.
+- Use documented theme, variables, and mixin layers.
+- Keep local overrides minimal and accessibility-aligned.
+
+## Guidance Links
+- https://designsystem.ontario.ca/foundations/
+- https://designsystem.ontario.ca/developer-docs/
+
+## Related Packages
+- @ongov/ontario-design-system-component-library
+- @ongov/ontario-design-system-component-library-react
+- @ongov/ontario-design-system-component-library-angular
+- @ongov/ontario-design-system-complete-styles

--- a/packages/ontario-design-system-global-styles/package.json
+++ b/packages/ontario-design-system-global-styles/package.json
@@ -10,7 +10,8 @@
 	"files": [
 		"dist/",
 		"package.json",
-		"README.md"
+		"README.md",
+		"llms.txt"
 	],
 	"scripts": {
 		"exports:generate": "node ./scripts/generate-scss-exports.mjs",


### PR DESCRIPTION
## Summary

Adds package-level `llms.txt` guidance and wires it into publish artifacts for target Ontario Design System packages.

## What Changed

- Added `llms.txt` files to:
  - `@ongov/ontario-design-system-component-library`
  - `@ongov/ontario-design-system-component-library-react`
  - `@ongov/ontario-design-system-component-library-angular`
  - `@ongov/ontario-design-system-global-styles`
  - `@ongov/ontario-design-system-complete-styles`
- Updated each package `files` array so `llms.txt` ships in npm artifacts.
- Added concise README cross-links to package-level AI guidance and related packages.

## Notes

- Branch base: `scott/epic/DS-2602-remediation`
- Scope intentionally limited to package guidance and discoverability updates.
