### PR TITLE
Switch docs auto-merge from rebase to merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           gh pr merge
           --repo ongov/design-system-developer-documentation-site
           --auto
-          --rebase
+          --merge
           ${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}
 
       - name: Summarise docs auto-merge handoff
@@ -98,5 +98,5 @@ jobs:
             echo "| Docs PR | [#${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}](${{ github.server_url }}/ongov/design-system-developer-documentation-site/pull/${{ needs.sync-docs-to-docusaurus.outputs.pull-request-number }}) |"
             echo "| PR operation | \`${{ needs.sync-docs-to-docusaurus.outputs.pull-request-operation }}\` |"
             echo "| Auto-merge step | \`${{ steps.enable_automerge.outcome }}\` |"
-            echo "| Merge method | \`rebase\` |"
+            echo "| Merge method | \`merge\` |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The docs repo is configured to format merge commit messages using the PR title and description, but the workflow was using `--rebase` which bypasses that setting entirely (it replays individual commits without creating a merge commit).

Switch to `--merge` so the repository's commit message format setting is honoured and the resulting commit message on `main` reads as the PR title/description.