### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,7 +34,7 @@ jobs:
         uses: pnpm/action-setup@v4.0.0
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v43.0.5
+        uses: renovatebot/github-action@v46.1.13
         env:
           # GitHub and NPM tokens must be set in the repository secrets
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- update the self-hosted Renovate workflow from `renovatebot/github-action@v43.0.5` to `v46.1.13`
- keep the existing `renovate.json` configuration file, token wiring, and event filters unchanged

## Verification
- checked the workflow diff for a single action-version replacement and no trailing whitespace

This is a workflow-only maintenance update, so I did not run the package/build test suite.
