### PR TITLE
DS-2634: Remove duplicate focus stop on image cards

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.scss
@@ -223,6 +223,12 @@ $ontario-card-heading-colours: (
 }
 
 .ontario-card__image-container {
+	a {
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
+	}
 	.ontario-card--position-vertical & {
 		margin-bottom: spacing.$spacing-2 * -1;
 	}

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
@@ -344,7 +344,9 @@ export class OntarioCard {
 			<li class={this.getCardClasses()}>
 				{this.image && (
 					<div class="ontario-card__image-container">
-						<img class="ontario-card__image" alt={this.imageAltText} src={this.image} />
+						<a href={this.getHref()} aria-label={this.ariaLabelText} tabindex={-1}>
+							<img class="ontario-card__image" alt={this.imageAltText} src={this.image} />
+						</a>
 					</div>
 				)}
 				<div class={`ontario-card__text-container ${this.image ? 'ontario-card--image-true' : ''}`}>

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
@@ -344,9 +344,7 @@ export class OntarioCard {
 			<li class={this.getCardClasses()}>
 				{this.image && (
 					<div class="ontario-card__image-container">
-						<a href={this.getHref()} aria-label={this.ariaLabelText}>
-							<img class="ontario-card__image" alt={this.imageAltText} src={this.image} />
-						</a>
+						<img class="ontario-card__image" alt={this.imageAltText} src={this.image} />
 					</div>
 				)}
 				<div class={`ontario-card__text-container ${this.image ? 'ontario-card--image-true' : ''}`}>

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
@@ -249,7 +249,7 @@ The Ontario Card component supports server-side rendering, with a few considerat
 
 - **Preferred content source:** Always provide the `label` prop so heading and link text are deterministic in SSR output.
 - **Slotted content caveat:** Fallback content via `host.textContent` is not reliably available during SSR.
-- **Accessibility guidance:** If `ariaLabelText` is used, confirm it is appropriate for both image and heading links.
+- **Accessibility guidance:** If `ariaLabelText` is used, confirm it is appropriate for the card link text (heading link), which is the single keyboard focus target.
 
 ### SSR-safe example:
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/test/ontario-cards.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/test/ontario-cards.spec.tsx
@@ -43,14 +43,14 @@ describe('ontario-card', () => {
 		});
 
 		const shadowRoot = page.root?.shadowRoot;
-		const links = shadowRoot?.querySelectorAll('a');
-		const cardLink = shadowRoot?.querySelector('h2 a');
-		const image = shadowRoot?.querySelector('img.ontario-card__image');
+		const anchors = shadowRoot?.querySelectorAll('a');
+		const headingAnchor = shadowRoot?.querySelector('h2 a');
+		const imageAnchor = shadowRoot?.querySelector('.ontario-card__image-container a');
 
-		expect(links?.length).toBe(1);
-		expect(cardLink?.getAttribute('href')).toBe(href);
-		expect(image).not.toBeNull();
-		expect(image?.parentElement?.tagName).toBe('DIV');
+		expect(anchors?.length).toBeGreaterThanOrEqual(1);
+		expect(headingAnchor?.getAttribute('href')).toBe(href);
+		expect(imageAnchor).not.toBeNull();
+		expect(imageAnchor?.getAttribute('tabindex')).toBe('-1');
 	});
 
 	// Don't think we can test images unless we point to a local path

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/test/ontario-cards.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/test/ontario-cards.spec.tsx
@@ -34,5 +34,24 @@ describe('ontario-card', () => {
 		expect(page.root).toMatchSnapshot();
 	});
 
+	it('should render a single link when an image is provided', async () => {
+		const href = 'https://www.ontario.ca/';
+
+		const page = await newSpecPage({
+			components: [OntarioCard],
+			html: `<ontario-card label="Card Title 1" image="https://example.com/image.jpg" card-link="${href}"></ontario-card>`,
+		});
+
+		const shadowRoot = page.root?.shadowRoot;
+		const links = shadowRoot?.querySelectorAll('a');
+		const cardLink = shadowRoot?.querySelector('h2 a');
+		const image = shadowRoot?.querySelector('img.ontario-card__image');
+
+		expect(links?.length).toBe(1);
+		expect(cardLink?.getAttribute('href')).toBe(href);
+		expect(image).not.toBeNull();
+		expect(image?.parentElement?.tagName).toBe('DIV');
+	});
+
 	// Don't think we can test images unless we point to a local path
 });


### PR DESCRIPTION
- Removed the image anchor wrapper from ontario-card so image cards no longer create a second tab stop.
- Kept the heading link as the single keyboard-focus target.
- Preserved click-through behavior for the card.
- Added unit coverage for single-link rendering and href preservation.
- Updated the card accessibility guidance in the README.