### PR TITLE
Fix incorrect setAssetPath value and asset copy paths in React and Angular READMEs (DS-2641)

### DIFF
--- a/packages/ontario-design-system-component-library-angular/README.md
+++ b/packages/ontario-design-system-component-library-angular/README.md
@@ -96,10 +96,10 @@ If your app serves component assets (fonts, images, favicons) from a non-root pa
 ```typescript
 import { setAssetPath } from '@ongov/ontario-design-system-component-library-angular';
 
-setAssetPath(`${window.location.origin}/assets/`);
+setAssetPath(`${window.location.origin}`);
 ```
 
-## Usage
+If your app serves component assets (fonts, images, favicons) from a non-root path, configure the asset base path before components render. Pass `window.location.origin` (no `/assets/` suffix) — the library's internal asset helper appends the correct path segment automatically.
 
 You can now use the Angular Components in your component template files.
 
@@ -116,16 +116,16 @@ The assets in the npm package are located at `@ongov/ontario-design-system-compo
 In a standard Angular application this can be done in a number of ways. One way is to use the [copyfiles](https://www.npmjs.com/package/copyfiles) npm package, which you can with any operating system:
 
 ```bash
-copyfiles -E -f "node_modules/@ongov/ontario-design-system-component-library-angular/dist/assets/*" src/assets
+copyfiles -E -f "node_modules/@ongov/ontario-design-system-component-library-angular/dist/assets/images/**" src/assets
 ```
 
 Another way is to add scripts to copy the assets in your `package.json` file. For example:
 
 ```json
 "prebuild": "npm run copy:assets",
-"copy:images": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/component-library/assets/images/**\" src/assets",
-"copy:favicons": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/component-library/assets/favicons/**\" src/assets/favicons",
-"copy:fonts": "copyfiles -E -u 6 \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/component-library/assets/fonts/**/*\" src/assets/fonts",
+"copy:images": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/assets/images/**\" src/assets",
+"copy:favicons": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/assets/favicons/**\" src/assets/favicons",
+"copy:fonts": "copyfiles -E -u 6 \"node_modules/@ongov/ontario-design-system-component-library-angular/dist/assets/fonts/**/*\" src/assets/fonts",
 "copy:assets": "npm run copy:images && npm run copy:favicons && npm run copy:fonts"
 ```
 

--- a/packages/ontario-design-system-component-library-react/README.md
+++ b/packages/ontario-design-system-component-library-react/README.md
@@ -49,10 +49,10 @@ To use the Ontario Design System React component library, follow these steps:
    ```tsx
    import { setAssetPath } from '@ongov/ontario-design-system-component-library-react';
 
-   setAssetPath(`${window.location.origin}/assets/`);
+   setAssetPath(`${window.location.origin}`);
    ```
 
-   Call `setAssetPath` once, before rendering any components. This ensures Stencil can resolve component assets (fonts, images, favicons) when they are hosted under a custom base path.
+   Call `setAssetPath` once, before rendering any components. This ensures Stencil can resolve component assets (fonts, images, favicons) when they are hosted under a custom base path. Pass `window.location.origin` (no `/assets/` suffix) — the library's internal asset helper appends the correct path segment automatically.
 
    If you need to override the global styles theme with a custom asset base path, you can create a local theme wrapper that forwards the global styles and sets `$asset-base-path`, then import that wrapper in your app entry point.
 
@@ -106,16 +106,16 @@ The assets in the npm package are located at `@ongov/ontario-design-system-compo
 In a standard React application this can be done in a number of ways. One way is to use the [copyfiles](https://www.npmjs.com/package/copyfiles) npm package, which you can with any operating system:
 
 ```bash
-copyfiles -E -f "node_modules/@ongov/ontario-design-system-component-library-react/dist/assets/*" src/assets
+copyfiles -E -f "node_modules/@ongov/ontario-design-system-component-library-react/dist/assets/images/**" public/assets
 ```
 
 Another way is to add scripts to copy the assets in your `package.json` file. For example:
 
 ```json
 "prebuild": "npm run copy:assets",
-"copy:images": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-react/dist/component-library/assets/images/**\" src/assets",
-"copy:favicons": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-react/dist/component-library/assets/favicons/**\" src/assets/favicons",
-"copy:fonts": "copyfiles -E -u 6 \"node_modules/@ongov/ontario-design-system-component-library-react/dist/component-library/assets/fonts/**/*\" src/assets/fonts",
+"copy:images": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-react/dist/assets/images/**\" public/assets",
+"copy:favicons": "copyfiles -E -f \"node_modules/@ongov/ontario-design-system-component-library-react/dist/assets/favicons/**\" public/assets/favicons",
+"copy:fonts": "copyfiles -E -u 6 \"node_modules/@ongov/ontario-design-system-component-library-react/dist/assets/fonts/**/*\" public/assets/fonts",
 "copy:assets": "npm run copy:images && npm run copy:favicons && npm run copy:fonts"
 ```
 


### PR DESCRIPTION
## Summary

- Corrects the documented `setAssetPath` value from `${window.location.origin}/assets/` to `${window.location.origin}` in both the React and Angular README files
- Fixes the `copy:images` glob paths, which referenced a non-existent `dist/component-library/assets/` path
- Fixes the one-liner copy command to use `dist/assets/images/**` with `-f` so images land flat in the destination
- Updates the React copy destination from `src/assets` to `public/assets` to match Vite/CRA convention

## Why

The `/assets/` suffix in `setAssetPath` caused Stencil's URL resolution to produce a double-segment path (`/assets/assets/foo.svg`), resulting in a silent 404 for all component images. This was the root cause of the missing dropdown arrow reported in DS-2641.

Our internal sample apps worked because they already used `${window.location.origin}` (no suffix) — the docs were simply wrong.

## Details

Stencil's `getAssetPath('./assets/foo.svg')` appends relative to the `setAssetPath` base using standard URL resolution. With a trailing-slash base of `http://example.com/assets/`, `./assets/foo.svg` resolves to `/assets/assets/foo.svg`. Passing `window.location.origin` only gives the correct `/assets/foo.svg`.

This is a **documentation-only change** — no library code was modified.

## Validation

- Verified fix in consumer app (Avi's minimal test project): clean build, correct asset resolution
- Internal sample apps (React, Angular, Next.js) unaffected — they already used the correct pattern
- Docusaurus README copies will update automatically on next build

## Risks

None — docs only.