### PR TITLE
DS-2258: Normalize OntarioCard headerColour values to camelCase

### DIFF
--- a/packages/app-nextjs/src/app/components/ontario-card/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-card/page.tsx
@@ -78,128 +78,128 @@ export default function OntarioCardPage() {
 				></OntarioCard>
 
 				<h2>&apos;header-colour&apos; Prop Variants</h2>
-				<h3>Dark-accent</h3>
+				<h3>darkAccent</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="dark-accent"
-					label="Header colour is dark-accent"
+					headerColour="darkAccent"
+					label="Header colour is darkAccent"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-accent</h3>
+				<h3>lightAccent</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-accent"
-					label="Header colour is light-accent"
+					headerColour="lightAccent"
+					label="Header colour is lightAccent"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-gold</h3>
+				<h3>lightGold</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-gold"
-					label="Header colour is light-gold"
+					headerColour="lightGold"
+					label="Header colour is lightGold"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-yellow</h3>
+				<h3>lightYellow</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-yellow"
-					label="Header colour is light-yellow"
+					headerColour="lightYellow"
+					label="Header colour is lightYellow"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-taupe</h3>
+				<h3>lightTaupe</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-taupe"
-					label="Header colour is light-taupe"
+					headerColour="lightTaupe"
+					label="Header colour is lightTaupe"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-green</h3>
+				<h3>lightGreen</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-green"
-					label="Header colour is light-green"
+					headerColour="lightGreen"
+					label="Header colour is lightGreen"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-lime</h3>
+				<h3>lightLime</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-lime"
-					label="Header colour is light-lime"
+					headerColour="lightLime"
+					label="Header colour is lightLime"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-teal</h3>
+				<h3>lightTeal</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-teal"
-					label="Header colour is light-teal"
+					headerColour="lightTeal"
+					label="Header colour is lightTeal"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-sky</h3>
+				<h3>lightSky</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-sky"
-					label="Header colour is light-sky"
+					headerColour="lightSky"
+					label="Header colour is lightSky"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-blue</h3>
+				<h3>lightBlue</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-blue"
-					label="Header colour is light-blue"
+					headerColour="lightBlue"
+					label="Header colour is lightBlue"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-purple</h3>
+				<h3>lightPurple</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-purple"
-					label="Header colour is light-purple"
+					headerColour="lightPurple"
+					label="Header colour is lightPurple"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-orange</h3>
+				<h3>lightOrange</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-orange"
-					label="Header colour is light-orange"
+					headerColour="lightOrange"
+					label="Header colour is lightOrange"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-red</h3>
+				<h3>lightRed</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-red"
-					label="Header colour is light-red"
+					headerColour="lightRed"
+					label="Header colour is lightRed"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>
 
-				<h3>Light-magenta</h3>
+				<h3>lightMagenta</h3>
 				<OntarioCard
 					headingLevel="h2"
-					headerColour="light-magenta"
-					label="Header colour is light-magenta"
+					headerColour="lightMagenta"
+					label="Header colour is lightMagenta"
 					layoutDirection="horizontal"
 					description="Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum"
 				></OntarioCard>

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card-types.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card-types.tsx
@@ -9,20 +9,20 @@ export type HorizontalImagePositionType = (typeof horizontalImagePositionDefinit
 export type HorizontalImageSizeType = (typeof horizontalImageSizeDefinitions)[number];
 
 export const headerColourDefinitions = [
-	'dark-accent',
-	'light-accent',
-	'light-gold',
-	'light-yellow',
-	'light-taupe',
-	'light-green',
-	'light-lime',
-	'light-teal',
-	'light-sky',
-	'light-blue',
-	'light-purple',
-	'light-orange',
-	'light-red',
-	'light-magenta',
+	'darkAccent',
+	'lightAccent',
+	'lightGold',
+	'lightYellow',
+	'lightTaupe',
+	'lightGreen',
+	'lightLime',
+	'lightTeal',
+	'lightSky',
+	'lightBlue',
+	'lightPurple',
+	'lightOrange',
+	'lightRed',
+	'lightMagenta',
 	'gold',
 	'yellow',
 	'taupe',
@@ -38,6 +38,38 @@ export const headerColourDefinitions = [
 ] as const;
 
 export type HeaderColour = (typeof headerColourDefinitions)[number];
+
+/**
+ * Maps camelCase HeaderColour values to their corresponding CSS class suffixes.
+ */
+export const headerColourToClass: Record<HeaderColour, string> = {
+	darkAccent: 'dark-accent',
+	lightAccent: 'light-accent',
+	lightGold: 'light-gold',
+	lightYellow: 'light-yellow',
+	lightTaupe: 'light-taupe',
+	lightGreen: 'light-green',
+	lightLime: 'light-lime',
+	lightTeal: 'light-teal',
+	lightSky: 'light-sky',
+	lightBlue: 'light-blue',
+	lightPurple: 'light-purple',
+	lightOrange: 'light-orange',
+	lightRed: 'light-red',
+	lightMagenta: 'light-magenta',
+	gold: 'gold',
+	yellow: 'yellow',
+	taupe: 'taupe',
+	green: 'green',
+	lime: 'lime',
+	teal: 'teal',
+	sky: 'sky',
+	blue: 'blue',
+	purple: 'purple',
+	orange: 'orange',
+	red: 'red',
+	magenta: 'magenta',
+} as const;
 
 // Define properties that you would like to track as component state
 export type CardState = {

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/ontario-card.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, Element, h, State, Watch } from '@stencil/core';
 import {
 	headerColourDefinitions,
+	headerColourToClass,
 	HeaderColour,
 	HorizontalImagePositionType,
 	HorizontalImageSizeType,
@@ -299,8 +300,8 @@ export class OntarioCard {
 
 		const descriptionClass = this.description ? '' : ' ontario-card__description-false';
 
-		const backgroundClass =
-			this.headerColour && !this.description ? `ontario-card__background--${this.headerColour}` : '';
+		const colourClass = this.cardState.headerColour ? headerColourToClass[this.cardState.headerColour] : undefined;
+		const backgroundClass = colourClass && !this.description ? `ontario-card__background--${colourClass}` : '';
 
 		return `${baseClass} ${descriptionClass} ${backgroundClass}`.trim();
 	}
@@ -313,7 +314,8 @@ export class OntarioCard {
 	private getCardHeadingClasses(): string {
 		const baseClass = 'ontario-card__heading';
 
-		const backgroundClass = this.cardState.headerColour ? `ontario-card__heading--${this.cardState.headerColour}` : '';
+		const colourClass = this.cardState.headerColour ? headerColourToClass[this.cardState.headerColour] : undefined;
+		const backgroundClass = colourClass ? `ontario-card__heading--${colourClass}` : '';
 
 		return `${baseClass} ${backgroundClass}`.trim();
 	}

--- a/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-card/readme.md
@@ -216,20 +216,20 @@ This is another example of an `ontario-card` component with a horizontal layout 
 
 The `header-colour` property supports a wide range of values, including:
 
-- `dark-accent`
-- `light-accent`
-- `light-gold`
-- `light-yellow`
-- `light-taupe`
-- `light-green`
-- `light-lime`
-- `light-teal`
-- `light-sky`
-- `light-blue`
-- `light-purple`
-- `light-orange`
-- `light-red`
-- `light-magenta`
+- `darkAccent`
+- `lightAccent`
+- `lightGold`
+- `lightYellow`
+- `lightTaupe`
+- `lightGreen`
+- `lightLime`
+- `lightTeal`
+- `lightSky`
+- `lightBlue`
+- `lightPurple`
+- `lightOrange`
+- `lightRed`
+- `lightMagenta`
 - `gold`
 - `yellow`
 - `taupe`


### PR DESCRIPTION
Renames multi-word `headerColour` values from kebab-case to camelCase
(e.g. `dark-accent` → `darkAccent`) to align with `OntarioBadge` naming.

- Renamed multi-word colour values to camelCase
- Added `headerColourToClass` to preserve kebab-case CSS class names internally
- Updated app-nextjs demo page and readme

## Breaking change

Multi-word `headerColour` values are now camelCase (`dark-accent` → `darkAccent`,
`light-teal` → `lightTeal`). Single-word values (`sky`, `gold`) are unaffected.