### PR TITLE
DS-1931: Allow HTML/SVG content inside ontario-button via slot

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.scss
@@ -51,6 +51,11 @@ $ontario-button-bg-secondary: colours.$ontario-colour-white;
 	.ontario-icon {
 		margin-right: 4px;
 	}
+
+	::slotted(svg),
+	::slotted(img) {
+		vertical-align: middle;
+	}
 }
 
 .ontario-button--primary {

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
@@ -155,10 +155,11 @@ export class OntarioButton implements Button {
 	}
 
 	/**
-	 * Print the missing `label` prop warning message
+	 * Print the missing `label` prop warning message.
+	 * Skipped when `ariaLabelText` is provided, e.g. when using slotted SVG content.
 	 */
 	validateLabelContent(newValue: string) {
-		if (validatePropExists(newValue)) {
+		if (validatePropExists(newValue) && !this.ariaLabelText) {
 			const message = new ConsoleMessageClass();
 			message
 				.addDesignSystemTag()
@@ -281,6 +282,8 @@ export class OntarioButton implements Button {
 	}
 
 	render() {
+		const content = this.label ? this.labelState : <slot />;
+
 		if (this.isLinkMode()) {
 			return (
 				<a
@@ -291,7 +294,7 @@ export class OntarioButton implements Button {
 					aria-label={this.ariaLabelText}
 					id={this.getId()}
 				>
-					{this.labelState}
+					{content}
 				</a>
 			);
 		}
@@ -304,7 +307,7 @@ export class OntarioButton implements Button {
 				aria-label={this.ariaLabelText}
 				id={this.getId()}
 			>
-				{this.labelState}
+				{content}
 			</button>
 		);
 	}

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/test/ontario-button.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/test/ontario-button.spec.tsx
@@ -13,7 +13,7 @@ it('should render a default button', async () => {
     <ontario-button>
       <mock:shadow-root>
         <button aria-label="Element Content" class="ontario-button ontario-button--secondary" type="button">
-          Element Content
+          <slot></slot>
         </button>
       </mock:shadow-root>
       Element Content
@@ -30,7 +30,7 @@ it('should render a primary submit button', async () => {
     <ontario-button type="primary" html-type="submit">
       <mock:shadow-root>
         <button aria-label="Element Content" class="ontario-button ontario-button--primary" type="submit">
-          Element Content
+          <slot></slot>
         </button>
       </mock:shadow-root>
       Element Content
@@ -64,7 +64,7 @@ it('should render a default button with the aria-label-text attribute being over
     <ontario-button aria-label-text="Aria Label">
       <mock:shadow-root>
         <button aria-label="Aria Label" class="ontario-button ontario-button--secondary" type="button">
-          Element Content
+          <slot></slot>
         </button>
       </mock:shadow-root>
       Element Content
@@ -81,7 +81,7 @@ it('should render a default button with an id being explicity specified', async 
     <ontario-button element-id="DefaultButton">
       <mock:shadow-root>
         <button aria-label="Element Content" class="ontario-button ontario-button--secondary" type="button" id="DefaultButton">
-          Element Content
+          <slot></slot>
         </button>
       </mock:shadow-root>
       Element Content
@@ -98,7 +98,7 @@ it('should render as a link when href is provided', async () => {
     <ontario-button href="/services" target="_blank" rel="noreferrer">
       <mock:shadow-root>
         <a aria-label="Browse services" class="ontario-button ontario-button--secondary" href="/services" rel="noreferrer" target="_blank">
-          Browse services
+          <slot></slot>
         </a>
       </mock:shadow-root>
       Browse services
@@ -115,10 +115,27 @@ it('should ignore submit htmlType when rendering as a link', async () => {
     <ontario-button href="/services" html-type="submit" type="primary">
       <mock:shadow-root>
         <a aria-label="Browse services" class="ontario-button ontario-button--primary" href="/services">
-          Browse services
+          <slot></slot>
         </a>
       </mock:shadow-root>
       Browse services
+    </ontario-button>
+  `);
+});
+
+it('should render slotted SVG content inside the button', async () => {
+	const page = await newSpecPage({
+		components: [OntarioButton],
+		html: `<ontario-button aria-label-text="Open map"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/></svg></ontario-button>`,
+	});
+	expect(page.root).toEqualHtml(`
+    <ontario-button aria-label-text="Open map">
+      <mock:shadow-root>
+        <button aria-label="Open map" class="ontario-button ontario-button--secondary" type="button">
+          <slot></slot>
+        </button>
+      </mock:shadow-root>
+      <svg aria-hidden="true" focusable="false" viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"></path></svg>
     </ontario-button>
   `);
 });

--- a/packages/ontario-design-system-component-library/src/index.html
+++ b/packages/ontario-design-system-component-library/src/index.html
@@ -179,6 +179,22 @@
 						<ontario-button aria-label-text="Secondary Button" htmlType="reset">Secondary</ontario-button>
 						<h3 class="ontario-h4">Tertiary button</h3>
 						<ontario-button aria-label-text="Tertiary Button" type="tertiary">Tertiary</ontario-button>
+						<h3 class="ontario-h4">SVG button (slotted)</h3>
+						<ontario-button aria-label-text="Open map" type="primary">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								width="24"
+								height="24"
+								aria-hidden="true"
+								focusable="false"
+							>
+								<path
+									fill="currentColor"
+									d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+								/>
+							</svg>
+						</ontario-button>
 						<hr />
 					</ontario-form-container>
 


### PR DESCRIPTION
Fixes HTML/SVG content being stripped when passed as children to `ontario-button`. The component read `host.textContent` and rendered it as a plain string, discarding any markup.

- Render `<slot>` instead of the text string when no `label` prop is set
- Suppress the missing-label warning when `aria-label-text` is provided
- Vertically align slotted `<svg>` and `<img>` elements

## Example:
```html
<ontario-button aria-label-text="Open map">
  <svg aria-hidden="true" focusable="false">...</svg>
</ontario-button>
```