### PR TITLE
DS-2236: Fix highlight prop breaking `ontario-table` in Next.js SSR

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
@@ -177,6 +177,7 @@ $ontario-table-caption-custom-spacing: spacing.$spacing-4 + math.div(spacing.$sp
 				// Distance from top of svg to top of container
 				top: globalFunctions.px-to-rem(24);
 				left: 0;
+				fill: colours.$ontario-colour-yellow;
 			}
 		}
 	}

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
@@ -170,14 +170,13 @@ $ontario-table-caption-custom-spacing: spacing.$spacing-4 + math.div(spacing.$sp
 			display: flex;
 			position: relative;
 
-			svg.ontario-table--highlight-indicator {
+			img.ontario-table--highlight-indicator {
 				// Width of yellow triangle svg
 				width: globalFunctions.px-to-rem(8);
 				position: absolute;
 				// Distance from top of svg to top of container
 				top: globalFunctions.px-to-rem(24);
 				left: 0;
-				fill: colours.$ontario-colour-yellow;
 			}
 		}
 	}
@@ -332,7 +331,7 @@ $ontario-table-caption-custom-spacing: spacing.$spacing-4 + math.div(spacing.$sp
 		padding: spacing.$spacing-3 spacing.$spacing-4 spacing.$spacing-3 spacing.$spacing-5;
 	}
 
-	tr.ontario-table-row--highlight th svg.ontario-table--highlight-indicator {
+	tr.ontario-table-row--highlight th img.ontario-table--highlight-indicator {
 		top: globalFunctions.px-to-rem(17);
 	}
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.scss
@@ -170,7 +170,7 @@ $ontario-table-caption-custom-spacing: spacing.$spacing-4 + math.div(spacing.$sp
 			display: flex;
 			position: relative;
 
-			img.ontario-table--highlight-indicator {
+			svg.ontario-table--highlight-indicator {
 				// Width of yellow triangle svg
 				width: globalFunctions.px-to-rem(8);
 				position: absolute;
@@ -331,7 +331,7 @@ $ontario-table-caption-custom-spacing: spacing.$spacing-4 + math.div(spacing.$sp
 		padding: spacing.$spacing-3 spacing.$spacing-4 spacing.$spacing-3 spacing.$spacing-5;
 	}
 
-	tr.ontario-table-row--highlight th img.ontario-table--highlight-indicator {
+	tr.ontario-table-row--highlight th svg.ontario-table--highlight-indicator {
 		top: globalFunctions.px-to-rem(17);
 	}
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
@@ -247,7 +247,7 @@ export class OntarioTable implements Table {
 									aria-hidden="true"
 									focusable="false"
 								>
-									<polygon points="0,0 11.3,11.3 0,22.6" fill="#FCAF17" />
+									<polygon points="0,0 11.3,11.3 0,22.6" />
 								</svg>
 							)}
 						</th>

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Element, Prop, State, Watch, getAssetPath } from '@stencil/core';
+import { Component, h, Element, Prop, State, Watch } from '@stencil/core';
 
 import { Table, TableColumnOptions, TableRowOptions } from './table.interface';
 
@@ -98,11 +98,11 @@ export class OntarioTable implements Table {
 	 */
 	@Prop() fullWidth?: boolean | undefined = false;
 
-	@State() private tableColumnsState: TableColumnOptions[];
+	@State() private tableColumnsState: TableColumnOptions[] = [];
 
-	@State() private tableDataState: TableRowOptions[];
+	@State() private tableDataState: TableRowOptions[] = [];
 
-	@State() private tableFooterState: TableRowOptions[];
+	@State() private tableFooterState: TableRowOptions[] = [];
 
 	@Watch('tableColumns')
 	private processTableColumns() {
@@ -261,6 +261,7 @@ export class OntarioTable implements Table {
 
 	// Helper function to apply the scrollbar styles to the tops of tables
 	private applyScrollbar(tableElement: Element, scrollerDiv: HTMLElement) {
+		if (!scrollerDiv || !tableElement) return;
 		scrollerDiv.style.visibility = 'visible';
 		scrollerDiv.style.height = '20px';
 		scrollerDiv.style.width = `${tableElement.scrollWidth}px`;

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
@@ -7,6 +7,7 @@ import { validateTableColumns, validateTableRowOptions } from './utils/ontario-t
 import { ConsoleMessageClass } from '../../utils/console-message/console-message';
 import { ConsoleType } from '../../utils/console-message/console-message.enum';
 import { extractValuesByKey, organizeObjectKeys, removeObjectsBySpecificKey } from '../../utils/helper/utils';
+import { getImageAssetSrcPath } from '../../utils/helper/assets';
 
 /**
  * Ontario Table presents structured tabular data with accessible semantics.
@@ -240,15 +241,12 @@ export class OntarioTable implements Table {
 					return index === 0 ? (
 						<th scope="row" innerHTML={rowData.data[`${columns[0]}`]}>
 							{dataType === 'tableData' && rowData.highlight && (
-								<svg
+								<img
 									class="ontario-table--highlight-indicator"
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 11.3 22.6"
+									src={getImageAssetSrcPath('highlight-indicator.svg')}
+									alt=""
 									aria-hidden="true"
-									focusable="false"
-								>
-									<polygon points="0,0 11.3,11.3 0,22.6" />
-								</svg>
+								/>
 							)}
 						</th>
 					) : (

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/ontario-table.tsx
@@ -240,11 +240,15 @@ export class OntarioTable implements Table {
 					return index === 0 ? (
 						<th scope="row" innerHTML={rowData.data[`${columns[0]}`]}>
 							{dataType === 'tableData' && rowData.highlight && (
-								<img
+								<svg
 									class="ontario-table--highlight-indicator"
-									src={getAssetPath('./assets/highlight-indicator.svg')}
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 11.3 22.6"
 									aria-hidden="true"
-								></img>
+									focusable="false"
+								>
+									<polygon points="0,0 11.3,11.3 0,22.6" fill="#FCAF17" />
+								</svg>
 							)}
 						</th>
 					) : (

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
@@ -226,7 +226,7 @@ exports[`ontario-table snapshot - 5 columns (numeric) should render the expected
               <th scope="row">
                 Forestry
                 <svg aria-hidden="true" class="ontario-table--highlight-indicator" focusable="false" viewBox="0 0 11.3 22.6" xmlns="http://www.w3.org/2000/svg">
-                  <polygon fill="#FCAF17" points="0,0 11.3,11.3 0,22.6"></polygon>
+                  <polygon points="0,0 11.3,11.3 0,22.6"></polygon>
                 </svg>
               </th>
               <td class="ontario-table-cell--numeric">

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
@@ -147,7 +147,7 @@ exports[`ontario-table snapshot - 5 columns (numeric) should render the expected
 								&quot;date4&quot;: &quot;46&quot;
 							}
 						},
-						{
+						{ 
 							&quot;data&quot;: {
 								&quot;business&quot;: &quot;Total row&quot;,
 								&quot;date1&quot;: &quot;514&quot;,
@@ -368,7 +368,7 @@ exports[`ontario-table snapshot - 7 columns (numeric and condensed) should rende
 								&quot;column6&quot;: &quot;36,264,081&quot;
 							}
 						},
-						{
+						{ 
 							&quot;data&quot; : {
 								&quot;program&quot;: &quot;Ministry total operating expense&quot;,
 								&quot;column1&quot;: &quot;6,713,690,314&quot;,

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
@@ -147,7 +147,7 @@ exports[`ontario-table snapshot - 5 columns (numeric) should render the expected
 								&quot;date4&quot;: &quot;46&quot;
 							}
 						},
-						{ 
+						{
 							&quot;data&quot;: {
 								&quot;business&quot;: &quot;Total row&quot;,
 								&quot;date1&quot;: &quot;514&quot;,
@@ -225,7 +225,9 @@ exports[`ontario-table snapshot - 5 columns (numeric) should render the expected
             <tr class="ontario-table-row--highlight">
               <th scope="row">
                 Forestry
-                <img aria-hidden="true" class="ontario-table--highlight-indicator" src="/assets/highlight-indicator.svg">
+                <svg aria-hidden="true" class="ontario-table--highlight-indicator" focusable="false" viewBox="0 0 11.3 22.6" xmlns="http://www.w3.org/2000/svg">
+                  <polygon fill="#FCAF17" points="0,0 11.3,11.3 0,22.6"></polygon>
+                </svg>
               </th>
               <td class="ontario-table-cell--numeric">
                 182
@@ -366,7 +368,7 @@ exports[`ontario-table snapshot - 7 columns (numeric and condensed) should rende
 								&quot;column6&quot;: &quot;36,264,081&quot;
 							}
 						},
-						{ 
+						{
 							&quot;data&quot; : {
 								&quot;program&quot;: &quot;Ministry total operating expense&quot;,
 								&quot;column1&quot;: &quot;6,713,690,314&quot;,

--- a/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
+++ b/packages/ontario-design-system-component-library/src/components/ontario-table/test/__snapshots__/ontario-table.spec.tsx.snap
@@ -225,9 +225,7 @@ exports[`ontario-table snapshot - 5 columns (numeric) should render the expected
             <tr class="ontario-table-row--highlight">
               <th scope="row">
                 Forestry
-                <svg aria-hidden="true" class="ontario-table--highlight-indicator" focusable="false" viewBox="0 0 11.3 22.6" xmlns="http://www.w3.org/2000/svg">
-                  <polygon points="0,0 11.3,11.3 0,22.6"></polygon>
-                </svg>
+                <img alt="" aria-hidden="true" class="ontario-table--highlight-indicator" src="/assets/highlight-indicator.svg">
               </th>
               <td class="ontario-table-cell--numeric">
                 182


### PR DESCRIPTION
Fixes `ontario-table` breaking in Next.js SSR environments when `highlight: true` is set on a `tableData` row.

- Replace `getAssetPath` highlight indicator image with an inline SVG
- Move SVG fill colour to `colours.$ontario-colour-yellow` design token in SCSS
- Initialize state arrays to `[]` to prevent undefined errors during SSR hydration
- Add null guard to `applyScrollbar` to prevent errors before DOM refs are assigned
- Update snapshot to reflect inline SVG output