### PR TITLE
Fix `app-angular` compile error after `@ngx-translate/http-loader` v17 upgrade

### DIFF
--- a/packages/app-angular/src/app/app.module.ts
+++ b/packages/app-angular/src/app/app.module.ts
@@ -23,9 +23,11 @@ import { FrameSixComponent } from './pages/framesix/framesix.component';
 
 // import ngx-translate and the http loader
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
+import { TranslateHttpLoader, provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { NgxTranslateRoutesModule } from 'ngx-translate-routes';
-import { createTranslateLoader } from './translation.config';
+
+import { environment } from '../environments/environment';
 
 @NgModule({
 	declarations: [
@@ -54,8 +56,7 @@ import { createTranslateLoader } from './translation.config';
 			useDefaultLang: true,
 			loader: {
 				provide: TranslateLoader,
-				useFactory: createTranslateLoader,
-				deps: [HttpClient],
+				useClass: TranslateHttpLoader,
 			},
 		}),
 		NgxTranslateRoutesModule.forRoot({
@@ -64,7 +65,10 @@ import { createTranslateLoader } from './translation.config';
 		}),
 	],
 	schemas: [CUSTOM_ELEMENTS_SCHEMA],
-	providers: [TemporaryStorageService],
+	providers: [
+		TemporaryStorageService,
+		...provideTranslateHttpLoader({ prefix: environment.translationPath, suffix: '.json' }),
+	],
 	bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/packages/app-angular/src/app/translation.config.ts
+++ b/packages/app-angular/src/app/translation.config.ts
@@ -1,12 +1,5 @@
-import { HttpClient } from '@angular/common/http';
-import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { AppConstants } from './app.constants';
-
 import { environment } from '../environments/environment';
-
-export function createTranslateLoader(http: HttpClient) {
-	return new TranslateHttpLoader(http, environment.translationPath, '.json');
-}
 
 export function isAngularPOCEnvironment() {
 	return environment.translationPath.includes(AppConstants.BASE_URL_SEGMENT);


### PR DESCRIPTION
The Angular POC fails to compile due to a breaking API change in
`@ngx-translate/http-loader` v17. The `TranslateHttpLoader` constructor
no longer accepts arguments — configuration is now injected via
`provideTranslateHttpLoader()`.

This was caused by Renovate bumped the package to v17 in `e2861e4b` but the call site in
`translation.config.ts` was not updated at the time.

- Removed the `createTranslateLoader` factory function from `translation.config.ts`
- Updated `app.module.ts` to use `useClass: TranslateHttpLoader` and
  `provideTranslateHttpLoader()` with the existing translation path config

## Testing

Run `pnpm run serve` from `packages/app-angular` and confirm the app compiles
and loads at http://localhost:4200.