### PR TITLE
DS-1762: Fix htmlType submit and reset for OntarioButton

### DIFF
--- a/packages/app-nextjs/src/app/components/ontario-button/page.tsx
+++ b/packages/app-nextjs/src/app/components/ontario-button/page.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { Grid } from '../../grid';
 import { OntarioButton } from '@ongov/ontario-design-system-component-library-react';
 
 export default function OntarioButtonPage() {
+	const [submitted, setSubmitted] = useState(false);
+
 	return (
 		<main>
 			<Grid>
@@ -30,6 +33,24 @@ export default function OntarioButtonPage() {
 
 					<h3>Tertiary</h3>
 					<OntarioButton id="ontario-button-tertiary" type="tertiary" label="Tertiary Button"></OntarioButton>
+				</div>
+
+				<div>
+					<h2>"htmlType" Prop — Form Integration</h2>
+
+					{submitted && <p id="form-submitted-message">Form submitted!</p>}
+
+					<form
+						id="ontario-button-form"
+						onSubmit={(e) => {
+							e.preventDefault();
+							setSubmitted(true);
+						}}
+					>
+						<input id="form-input" name="test-input" defaultValue="" />
+						<OntarioButton id="ontario-button-submit" type="primary" htmlType="submit" label="Submit"></OntarioButton>
+						<OntarioButton id="ontario-button-reset" type="secondary" htmlType="reset" label="Reset"></OntarioButton>
+					</form>
 				</div>
 			</Grid>
 		</main>

--- a/packages/app-nextjs/tests/ontario-button/ontario-button.e2e.ts
+++ b/packages/app-nextjs/tests/ontario-button/ontario-button.e2e.ts
@@ -66,4 +66,23 @@ test.describe('Ontario Button', () => {
 		await page.click('#ontario-button-tertiary'); // has no onClick
 		expect(triggered).toBe(false);
 	});
+
+	// Tests for htmlType form integration
+	test.describe('htmlType form integration', () => {
+		test('should submit the form when htmlType is "submit"', async ({ page }) => {
+			await expect(page.locator('#form-submitted-message')).not.toBeVisible();
+			await page.click('#ontario-button-submit');
+			await expect(page.locator('#form-submitted-message')).toBeVisible();
+			await expect(page.locator('#form-submitted-message')).toHaveText('Form submitted!');
+		});
+
+		test('should reset form fields when htmlType is "reset"', async ({ page }) => {
+			const input = page.locator('#form-input');
+			await input.fill('test value');
+			await expect(input).toHaveValue('test value');
+
+			await page.click('#ontario-button-reset');
+			await expect(input).toHaveValue('');
+		});
+	});
 });

--- a/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-button/ontario-button.tsx
@@ -271,11 +271,17 @@ export class OntarioButton implements Button {
 		const options = { attributes: true };
 		observer.observe(this.host, options);
 
-		// Add a click event listener to handle submitting a form
-		if (!this.isLinkMode() && this.htmlTypeState === 'submit') {
+		// Shadow DOM prevents the internal button's type from interacting with the outer form natively.
+		// Use ElementInternals to trigger submit/reset programmatically on click instead.
+		if (!this.isLinkMode()) {
 			this.buttonRef.addEventListener('click', () => {
 				const { form } = this.internals;
-				form?.requestSubmit();
+				if (!form) return;
+				if (this.htmlTypeState === 'submit') {
+					form.requestSubmit();
+				} else if (this.htmlTypeState === 'reset') {
+					form.reset();
+				}
 			});
 		}
 	}


### PR DESCRIPTION
OntarioButton has a `htmlType` prop for form buttons, but it did not actually work inside a form because the component renders in Shadow DOM. This change fixes that by making submit and reset work the way users expect.

- Use `form.requestSubmit()` when `htmlType="submit"`
- Use `form.reset()` when `htmlType="reset"`
- Check `htmlType` at click time so later prop changes still work

- A form demo and Playwright tests were added so we can verify both cases:
    - Submit shows that the form handler runs
    - Reset shows that the input is cleared