### PR TITLE
DS-1761: Fix OntarioInput React ref mapping

### DIFF
--- a/packages/ontario-design-system-component-library-angular/projects/component-library/src/lib/stencil-generated/components.ts
+++ b/packages/ontario-design-system-component-library-angular/projects/component-library/src/lib/stencil-generated/components.ts
@@ -3381,7 +3381,8 @@ export declare interface OntarioIconYoutube extends Components.OntarioIconYoutub
 
 
 @ProxyCmp({
-  inputs: ['caption', 'customOnBlur', 'customOnChange', 'customOnFocus', 'customOnInput', 'elementId', 'enableLiveValidation', 'errorMessage', 'hintExpander', 'hintText', 'inputValidator', 'inputWidth', 'language', 'name', 'required', 'requiredValidationMessage', 'type', 'value']
+  inputs: ['caption', 'customOnBlur', 'customOnChange', 'customOnFocus', 'customOnInput', 'elementId', 'enableLiveValidation', 'errorMessage', 'hintExpander', 'hintText', 'inputValidator', 'inputWidth', 'language', 'name', 'required', 'requiredValidationMessage', 'type', 'value'],
+  methods: ['getInputElement']
 })
 @Component({
   selector: 'ontario-input',

--- a/packages/ontario-design-system-component-library-react/src/index.ts
+++ b/packages/ontario-design-system-component-library-react/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/components.js';
 export { setAssetPath } from '@ongov/ontario-design-system-component-library/components/index.js';
+export { OntarioInput } from './overrides/ontario-input-ref.js';

--- a/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
+++ b/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
@@ -32,7 +32,7 @@ const mapHostRefToNativeInput = (hostElement: HTMLElement | null, ref: React.For
 	hostWithInputMethod
 		.componentOnReady?.()
 		.then(() => assignInputRef())
-		.catch((_error: unknown): void => undefined);
+		.catch(() => {});
 };
 
 type OntarioInputProps = React.ComponentPropsWithoutRef<typeof GeneratedOntarioInput>;

--- a/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
+++ b/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 
 import { OntarioInput as GeneratedOntarioInput } from '../components/components.js';

--- a/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
+++ b/packages/ontario-design-system-component-library-react/src/overrides/ontario-input-ref.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { OntarioInput as GeneratedOntarioInput } from '../components/components.js';
+import { setRef } from '../react-component-lib/utils/index.js';
+
+type OntarioInputHostElement = HTMLElement & {
+	getInputElement?: () => Promise<HTMLInputElement | null>;
+	componentOnReady?: () => Promise<unknown>;
+};
+
+const mapHostRefToNativeInput = (hostElement: HTMLElement | null, ref: React.ForwardedRef<unknown>) => {
+	if (!ref) {
+		return;
+	}
+
+	if (!hostElement) {
+		setRef(ref, null);
+		return;
+	}
+
+	const hostWithInputMethod = hostElement as OntarioInputHostElement;
+
+	const assignInputRef = async () => {
+		const inputElement = await hostWithInputMethod.getInputElement?.();
+		setRef(ref, inputElement ?? null);
+	};
+
+	assignInputRef().catch((_error: unknown): void => undefined);
+
+	hostWithInputMethod
+		.componentOnReady?.()
+		.then(() => assignInputRef())
+		.catch((_error: unknown): void => undefined);
+};
+
+type OntarioInputProps = React.ComponentPropsWithoutRef<typeof GeneratedOntarioInput>;
+
+const OntarioInputOverride = React.forwardRef<unknown, OntarioInputProps>((props, forwardedRef) => {
+	const hostRef = React.useCallback(
+		(hostElement: HTMLElement | null) => {
+			mapHostRefToNativeInput(hostElement, forwardedRef);
+		},
+		[forwardedRef],
+	);
+
+	return React.createElement(GeneratedOntarioInput, {
+		...props,
+		ref: hostRef,
+	});
+});
+
+OntarioInputOverride.displayName = 'OntarioInput';
+
+export const OntarioInput = OntarioInputOverride as typeof GeneratedOntarioInput;

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
@@ -1,4 +1,16 @@
-import { Component, Event, h, Prop, State, Listen, Element, Watch, EventEmitter, AttachInternals } from '@stencil/core';
+import {
+	Component,
+	Event,
+	h,
+	Prop,
+	State,
+	Listen,
+	Element,
+	Watch,
+	EventEmitter,
+	AttachInternals,
+	Method,
+} from '@stencil/core';
 import { v4 as uuid } from 'uuid';
 
 import { Input } from '../../utils/common/input/input';
@@ -49,6 +61,7 @@ import { HeaderLanguageToggleEventDetails } from '../../utils/events/common-even
 export class OntarioInput implements TextInput {
 	@Element() element: HTMLElement;
 	@AttachInternals() internals: ElementInternals;
+	private inputFieldRef?: HTMLInputElement;
 
 	hintTextRef: HTMLOntarioHintTextElement | undefined;
 
@@ -421,6 +434,16 @@ export class OntarioInput implements TextInput {
 		return this.elementId ?? '';
 	}
 
+	/**
+	 * Returns the internal native input element.
+	 *
+	 * This can be used by framework wrappers that need a direct input reference.
+	 */
+	@Method()
+	async getInputElement(): Promise<HTMLInputElement | null> {
+		return this.inputFieldRef ?? null;
+	}
+
 	private getValue(): string | number {
 		return this.value ?? '';
 	}
@@ -473,6 +496,7 @@ export class OntarioInput implements TextInput {
 					className={this.getClass()}
 					id={this.getId()}
 					name={this.name}
+					ref={(el) => (this.inputFieldRef = el)}
 					onInput={(e) => this.handleEvent(e, EventType.Input)}
 					onChange={(e) => this.handleEvent(e, EventType.Change)}
 					onBlur={(e) => this.handleEvent(e, EventType.Blur)}

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -124,5 +124,44 @@ describe('ontario-input', () => {
 
 			expect(page.rootInstance.getId()).toEqual('input-id');
 		});
+
+		it('should return the internal input element when using getInputElement', async () => {
+			const page = await newSpecPage({
+				components: [OntarioInput],
+				html: `<ontario-input
+					name="input-name"
+					element-id="input-id"
+				></ontario-input>`,
+			});
+
+			const inputElement = await page.root?.getInputElement();
+			const shadowInput = page.root?.shadowRoot?.querySelector('input');
+
+			expect(inputElement).not.toBeNull();
+			expect(inputElement?.id).toBe('input-id');
+			expect(inputElement).toBe(shadowInput);
+		});
+
+		it('should keep input interactions working while exposing getInputElement', async () => {
+			const page = await newSpecPage({
+				components: [OntarioInput],
+				html: `<ontario-input
+					name="input-name"
+					element-id="input-id"
+					caption='{"captionText": "Ontario Input"}'
+				></ontario-input>`,
+			});
+
+			const shadowInput = page.root?.shadowRoot?.querySelector('input') as HTMLInputElement;
+			shadowInput.value = 'updated by user';
+			shadowInput.dispatchEvent(new Event('input'));
+			await page.waitForChanges();
+
+			const inputElement = await page.root?.getInputElement();
+
+			expect(inputElement).toBe(shadowInput);
+			expect(inputElement?.value).toBe('updated by user');
+			expect(page.rootInstance.value).toBe('updated by user');
+		});
 	});
 });

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -143,6 +143,21 @@ describe('ontario-input', () => {
 			expect(inputElement).toBe(shadowInput);
 		});
 
+		it('should return null from getInputElement when no internal input ref is available', async () => {
+			const page = await newSpecPage({
+				components: [OntarioInput],
+				html: `<ontario-input
+					name="input-name"
+					element-id="input-id"
+				></ontario-input>`,
+			});
+
+			expect(page.root).not.toBeNull();
+			(page.rootInstance as OntarioInput & { inputFieldRef?: HTMLInputElement }).inputFieldRef = undefined;
+
+			await expect(page.root?.getInputElement()).resolves.toBeNull();
+		});
+
 		it('should keep input interactions working while exposing getInputElement', async () => {
 			const page = await newSpecPage({
 				components: [OntarioInput],

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -134,6 +134,7 @@ describe('ontario-input', () => {
 				></ontario-input>`,
 			});
 
+			expect(page.root).not.toBeNull();
 			const inputElement = await page.root?.getInputElement();
 			const shadowInput = page.root?.shadowRoot?.querySelector('input');
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -153,7 +153,7 @@ describe('ontario-input', () => {
 			});
 
 			expect(page.root).not.toBeNull();
-			(page.rootInstance as OntarioInput & { inputFieldRef?: HTMLInputElement }).inputFieldRef = undefined;
+			(page.rootInstance as unknown as { inputFieldRef?: HTMLInputElement }).inputFieldRef = undefined;
 
 			await expect(page.root?.getInputElement()).resolves.toBeNull();
 		});


### PR DESCRIPTION
Fixes OntarioInput ref behavior for React so refs resolve to the native input element instead of the web component host, enabling uncontrolled form usage and smoother third-party form library integration.

- Added `getInputElement()` as a public method on `ontario-input` to expose the internal native input
- Stored a stable internal input reference in the component and returned it from `getInputElement()`
- Added unit tests for method identity and regression coverage for normal input interactions
- Added a focused React `OntarioInput` override that forwards refs to the native input via `getInputElement()`
- Kept generated React files untouched by implementing the override in non-generated source and export wiring