### PR TITLE
DS-1760: sync ontario-input form value when value prop changes externally

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.tsx
@@ -283,6 +283,7 @@ export class OntarioInput implements TextInput {
 	@Watch('value')
 	handleValueChange() {
 		this.hasBeenInteractedWith = this.hasBeenInteractedWith || !!this.value;
+		this.internals?.setFormValue?.(this.value ?? '');
 	}
 
 	/*

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/test/ontario-input.spec.tsx
@@ -125,4 +125,44 @@ describe('ontario-input', () => {
 			expect(page.rootInstance.getId()).toEqual('input-id');
 		});
 	});
+
+	describe('form association', () => {
+		it('should call setFormValue with the current value when handleValueChange is invoked', async () => {
+			const page = await newSpecPage({
+				components: [OntarioInput],
+				html: `<ontario-input
+					name="input-name"
+					element-id="input-id"
+					value="initial"
+					caption='{"captionText": "Ontario Input"}'
+				></ontario-input>`,
+			});
+
+			const setFormValueSpy = jest.fn();
+			page.rootInstance.internals = { setFormValue: setFormValueSpy };
+			page.rootInstance.value = 'updated value';
+			page.rootInstance.handleValueChange();
+
+			expect(setFormValueSpy).toHaveBeenCalledWith('updated value');
+		});
+
+		it('should call setFormValue with an empty string when value is cleared', async () => {
+			const page = await newSpecPage({
+				components: [OntarioInput],
+				html: `<ontario-input
+					name="input-name"
+					element-id="input-id"
+					value="initial"
+					caption='{"captionText": "Ontario Input"}'
+				></ontario-input>`,
+			});
+
+			const setFormValueSpy = jest.fn();
+			page.rootInstance.internals = { setFormValue: setFormValueSpy };
+			page.rootInstance.value = undefined;
+			page.rootInstance.handleValueChange();
+
+			expect(setFormValueSpy).toHaveBeenCalledWith('');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

When the `value` prop on `ontario-input` is updated from outside the component (e.g. from React or Angular state), `ElementInternals.setFormValue` was not being called. This meant the host element's form-associated value fell out of sync with the controlled value, breaking native `<form>` submission in programmatic update scenarios.

## Change

Added a `setFormValue` call to the `@Watch('value')` handler so that any external change to the `value` prop is immediately reflected to the native form:

```typescript
@Watch('value')
handleValueChange() {
  this.hasBeenInteractedWith = this.hasBeenInteractedWith || !!this.value;
  this.internals?.setFormValue?.(this.value ?? '');
}
```

## Tests

Two unit tests added to `ontario-input.spec.tsx` under a new `form association` describe block:

- **value set externally** — asserts `setFormValue` is called with the updated value when `handleValueChange` fires
- **value cleared** — asserts `setFormValue` is called with `''` when value is set to `undefined`

All existing unit tests continue to pass.

## Notes

This fix was identified during review of PR #250 (DS-1760), where it was bundled with a broader `defaultValue` change. Extracted here as a standalone, uncontroversial bugfix.
