### PR TITLE
DS-1919: Add missing checkbox and radio margin override in last form group

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
@@ -26,6 +26,10 @@ $ontario-checkbox-box-shadow-outline: globalFunctions.px-to-rem(4);
 	max-width: globalVariables.$standard-width;
 }
 
+:host-context(.ontario-form-group:last-of-type) .ontario-checkboxes {
+	margin-bottom: spacing.$spacing-0;
+}
+
 .ontario-checkboxes__item {
 	position: relative;
 	margin: 0 0 spacing.$spacing-4;

--- a/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-radio-buttons/ontario-radio-buttons.scss
@@ -26,6 +26,10 @@ $ontario-input-offset: math.div((globalVariables.$touch-target-size - $ontario-r
 	max-width: globalVariables.$standard-width;
 }
 
+:host-context(.ontario-form-group:last-of-type) .ontario-radios {
+	margin-bottom: spacing.$spacing-0;
+}
+
 .ontario-radios__item {
 	position: relative;
 	display: block;

--- a/packages/ontario-design-system-global-styles/src/styles/scss/5-layout/_form-group.layout.scss
+++ b/packages/ontario-design-system-global-styles/src/styles/scss/5-layout/_form-group.layout.scss
@@ -4,4 +4,9 @@
 @warn "The `ontario-form-group` class will be deprecated and replaced with a vertical spacing component in future.";
 .ontario-form-group:last-of-type {
 	margin-bottom: spacing.$spacing-8;
+
+	.ontario-checkboxes,
+	.ontario-radios {
+		margin-bottom: spacing.$spacing-0;
+	}
 }


### PR DESCRIPTION
Adds the missing checkbox and radio `margin-bottom` override for the last `.ontario-form-group`, matching the Fractal behavior described in DS-1919.

- Add the missing `.ontario-checkboxes` and `.ontario-radios` `margin-bottom: 0` override inside `.ontario-form-group:last-of-type`
- Add `:host-context(.ontario-form-group:last-of-type)` handling in `ontario-checkboxes` so the override applies through Shadow DOM
- Add matching `:host-context(.ontario-form-group:last-of-type)` handling in `ontario-radio-buttons`
- Keep the fix scoped to the existing form-group behavior without changing other spacing rules
- Align web component behavior with the Fractal reference and Angular POC expectation