### PR TITLE
Fix Docker Node.js version mismatch in Playwright image

### DIFF
--- a/docker/playwright/Dockerfile
+++ b/docker/playwright/Dockerfile
@@ -1,5 +1,18 @@
 FROM mcr.microsoft.com/playwright:v1.60.0-noble
 
+# The Playwright base image ships an older Node.js. Overwrite it with the version
+# declared in .nvmrc so the container stays in sync with the rest of the project.
+COPY .nvmrc .nvmrc
+RUN NODE_VERSION=$(cat .nvmrc) && \
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      aarch64) NODE_ARCH="linux-arm64" ;; \
+      *) NODE_ARCH="linux-x64" ;; \
+    esac && \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.gz" \
+    | tar -xz -C /usr/local --strip-components=1 && \
+    rm .nvmrc
+
 # Set the working directory
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Fixes a Node.js version mismatch in the local Docker-based Playwright test runner that caused `test:e2e:docker` to fail, and makes the Docker image build correctly on both `linux/amd64` (Linux) and `linux/arm64` (Apple Silicon Macs).

## Motivation

The `mcr.microsoft.com/playwright:v1.60.0-noble` base image ships Node.js v22.18.0, but Angular CLI now requires a minimum of v22.22.3. This caused the `@ongov/ontario-design-system-component-library-angular:build` step to fail with exit code 3 when running `test:e2e:docker` locally.

The CI `stencil-e2e-test` job is unaffected because it uses `actions/setup-node` with `node-version-file: '.nvmrc'` to overwrite the image's bundled Node.js before building — the local Docker flow has no equivalent step.

On Apple Silicon Macs, Docker pulls the native `arm64` variant of the Playwright image. Downloading a hardcoded `linux-x64` Node.js binary into an `arm64` container causes a QEMU architecture mismatch error (`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2'`).

## What changed

- **`docker/playwright/Dockerfile`:** Added a build step that:
  - Copies `.nvmrc` into the build context and reads the Node.js version from it, keeping the container automatically in sync with the rest of the project.
  - Detects the container's CPU architecture (`uname -m`) and downloads the matching Node.js tarball (`linux-x64` or `linux-arm64`), so the image builds correctly on both Linux and Apple Silicon Macs.

## Testing

- Built the Docker image locally on Linux (`linux/amd64`) with `scripts/docker-compose.sh build stencil-e2e-runner` — builds successfully with the correct Node.js version.
- `pnpm --filter @ongov/ontario-design-system-component-library test:e2e:docker -- -- ontario-summary-list-item.e2e.ts` no longer fails at the Angular build step.