### PR TITLE
DS-2686: Source shipped tokens partial from frozen snapshot

### DIFF
--- a/packages/ontario-design-system-global-styles/gulpfile.js
+++ b/packages/ontario-design-system-global-styles/gulpfile.js
@@ -73,7 +73,9 @@ task('sass:copy-dist', () => {
 	return src(paths.styles.scss).pipe(dest(paths.styles.output));
 });
 
-// Replace node_module reference of tokens file with actual token declaration
+// Inline the frozen token declarations as the shipped tokens partial so SCSS
+// consumers get concrete `$ontario-*` values without resolving the design-tokens
+// package (frozen snapshot lives in src; see paths.dsTokens and DS-2686).
 task('sass:copy-tokens', () => {
 	return fs.copyFile(paths.dsTokens.src, paths.dsTokens.dest);
 });

--- a/packages/ontario-design-system-global-styles/paths-constants.js
+++ b/packages/ontario-design-system-global-styles/paths-constants.js
@@ -12,7 +12,10 @@ const paths = {
 	favicons: './src/favicons',
 	index: './src/index.js',
 	dsTokens: {
-		src: '../ontario-design-system-design-tokens/dist/scss/_variables.scss',
+		// Source the shipped token declarations from the local frozen snapshot
+		// (committed in DS-2686) rather than the live design-tokens package, so the
+		// shipped SCSS partial is unaffected while design-tokens is rearchitected.
+		src: './src/styles/scss/1-variables/_tokens.frozen.scss',
 		dest: './dist/styles/scss/1-variables/_tokens.variables.scss',
 	},
 	output: {


### PR DESCRIPTION
## Summary

Follow-up to #280 (DS-2686). The freeze re-pointed the SCSS **compile** path at the frozen tokens but missed the **shipped** SCSS partial: the gulp build still inlined the live design-tokens output into `dist/styles/scss/1-variables/_tokens.variables.scss`. This PR closes that gap so the shipped partial is also sourced from the local frozen snapshot.

## Motivation

`global-styles` has two token paths:

| Path | Source | Status before this PR |
| --- | --- | --- |
| CSS compile (`ontario-theme.css`) | `src/` → `_tokens.variables.scss` (`@forward 'tokens.frozen'`) | ✅ frozen in #280 |
| Shipped SCSS partial (`dist/.../_tokens.variables.scss`) | gulp `sass:copy-tokens` copied the live `design-tokens` dist | ❌ still live |

SCSS consumers import the shipped partial, so renovating `design-tokens` (PR 2 onward) would have changed it — exactly what the freeze is meant to prevent.

## Changes

- `paths.dsTokens.src` now points at `./src/styles/scss/1-variables/_tokens.frozen.scss` instead of `../ontario-design-system-design-tokens/dist/scss/_variables.scss`.
- Updated the `sass:copy-tokens` task comment to match.

## Validation

- Rebuilt `global-styles`: compiled CSS (theme + fonts, normal + minified) is **byte-identical** to the prior build.
- The shipped `_tokens.variables.scss` declarations are identical to the frozen file (only the provenance header comment is added).
- No build-time reference to the design-tokens package output remains (remaining matches are comments/sourcemaps only).

## Context

Targets the Epic integration branch `scott/epic/DS-2685-primitive-tokens` (umbrella #279).

## Risks

- None for consumers; shipped token values are unchanged.
