### PR TITLE
Add build-apps CI job to catch app-breaking dependency bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       docs-artifacts-name:
         required: true
         type: string
+      app-build-artifacts-name:
+        required: true
+        type: string
     outputs: # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
       build-artifacts-name:
         description: 'Name of the artifacts archive of the built libraries'
@@ -16,9 +19,12 @@ on:
       docs-artifacts-name:
         description: 'Name of the artifacts archive of the built docs'
         value: ${{ inputs.docs-artifacts-name }}
+      app-build-artifacts-name:
+        description: 'Name of the artifacts archive of the built apps'
+        value: ${{ inputs.app-build-artifacts-name }}
 
 jobs:
-  build:
+  build-libs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the repo
@@ -89,4 +95,72 @@ jobs:
             echo "| --- | --- | --- | --- |"
             echo "| Build | \`${{ inputs.build-artifacts-name }}\` | \`${build_size:-unknown}\` | \`${{ steps.upload_build_artifacts.outcome }}\` |"
             echo "| Docs | \`${{ inputs.docs-artifacts-name }}\` | \`${docs_size:-unknown}\` | \`${{ steps.upload_docs_artifact.outcome }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Build the framework demo apps (app-angular, app-react, app-nextjs) against the
+  # libraries built above. Catches dependency bumps (e.g. Renovate PRs) that compile
+  # cleanly for the libs but break a consuming app, before any Playwright jobs spin up.
+  build-apps:
+    needs: ['build-libs']
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repo
+      - uses: actions/checkout@v7
+
+      # Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      # Setup Node.js
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      # Download the built libraries from build-libs
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.build-artifacts-name }}
+          path: ./packages
+
+      # Install dependencies with lockfile verification
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build the demo apps
+      - name: Build the apps
+        id: build_apps
+        run: pnpm run build-apps
+
+      # Upload app build artifacts so downstream test jobs (e.g. apps-e2e-test,
+      # apps-vrt-test) can reuse the already-built output instead of rebuilding.
+      - name: Upload app build artifacts
+        id: upload_app_build_artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.app-build-artifacts-name }}
+          compression-level: 9 # Best compression
+          path: | # Collect built app output only
+            packages/app-angular/dist/**/*
+            packages/app-react/build/**/*
+            packages/app-nextjs/.next/**/*
+
+      - name: Summarise app build outputs
+        if: ${{ always() }}
+        run: |
+          {
+            echo '## Build Apps'
+            echo ''
+            echo "| Repository | Event | Ref | SHA | Run | Build Step |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+            echo "| \`${{ github.repository }}\` | \`${{ github.event_name }}\` | \`${{ github.ref_name }}\` | \`${{ github.sha }}\` | [#${{ github.run_number }} attempt ${{ github.run_attempt }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) | \`${{ steps.build_apps.outcome }}\` |"
+            echo ''
+            echo '### Artifacts'
+            echo ''
+            echo "| Artifact | Name | Upload |"
+            echo "| --- | --- | --- |"
+            echo "| App Build | \`${{ inputs.app-build-artifacts-name }}\` | \`${{ steps.upload_app_build_artifacts.outcome }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       build-artifacts-name: 'build-artifacts'
       docs-artifacts-name: 'docs-artifacts'
+      app-build-artifacts-name: 'app-build-artifacts'
 
   # Run test suites for the project.
   test: # Job defined in a separate file (test.yml)
@@ -28,6 +29,7 @@ jobs:
       checks: write
     with:
       build-artifacts-name: ${{ needs.build.outputs.build-artifacts-name }}
+      app-build-artifacts-name: ${{ needs.build.outputs.app-build-artifacts-name }}
 
   # Predict the next release tag before publishing so docs PRs can be prepared earlier.
   predict-release-tag:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       build-artifacts-name:
         required: true
         type: string
+      app-build-artifacts-name:
+        required: true
+        type: string
 
 jobs:
   stencil-unit-test:
@@ -214,10 +217,18 @@ jobs:
           name: ${{ inputs.build-artifacts-name }}
           path: ./packages
 
+      - name: Download app build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.app-build-artifacts-name }}
+          path: ./packages
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run Apps VRT Tests
+        env:
+          SKIP_APP_BUILD: 'true' # apps were already built in the build-apps job
         run: pnpm run test:vrt:apps
 
       - name: Upload Next.js VRT Test Results
@@ -283,10 +294,18 @@ jobs:
           name: ${{ inputs.build-artifacts-name }}
           path: ./packages
 
+      - name: Download app build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.app-build-artifacts-name }}
+          path: ./packages
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run All E2E Apps Tests
+        env:
+          SKIP_APP_BUILD: 'true' # apps were already built in the build-apps job
         run: pnpm run test:e2e:apps
 
       - name: Upload Next.js E2E Apps Test Results

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -9,6 +9,10 @@ set -x
 # Go to the app directory
 cd "$(dirname "$0")/../packages/app-nextjs"
 
-# Build and start the app
-pnpm run build
+# Build the app, unless it was already built upstream (e.g. by the build-apps CI job)
+if [ "$SKIP_APP_BUILD" != "true" ]; then
+	pnpm run build
+fi
+
+# Start the app
 pnpm run start


### PR DESCRIPTION
## Summary

Adds a `build-apps` job to CI so that `app-angular` and `app-react` are actually built on every PR, not just `app-nextjs`. Right now, dependency bumps (Renovate or otherwise) can merge with a fully green CI pipeline even if they break the Angular or React demo apps, because `build.yml` only runs `pnpm run build-libs`, and `test.yml`'s app-scoped jobs silently skip `app-angular`/`app-react` since neither package defines a `test:e2e`/`test:vrt` script for lerna to run. `app-nextjs` only gets exercised indirectly, as a side effect of its own Playwright `webServer` script (`scripts/start-server.sh`), which builds and starts it before running tests against it.

This was discovered while reviewing #288, #289, and #290 (the `@ngx-translate/core`, `@ngx-translate/http-loader`, and `@uirouter/angular` Renovate PRs): `app-angular` currently fails to build on `develop` due to a duplicate `@angular/core` version resolution (`22.0.0` vs `22.0.5`), and `@ngx-translate/core` v18 removes `TranslateModule` entirely, breaking the app's translation setup. Neither of these would have surfaced in CI without manually building the app locally.

## Changes

- Renamed the existing `build` job in `build.yml` to `build-libs` for clarity, since there are now two build jobs.
- Added a `build-apps` job (`needs: ['build-libs']`) that downloads the `build-libs` artifact, installs dependencies, and runs `pnpm run build-apps`, which covers `app-angular`, `app-react`, and `app-nextjs` in one shot (via the existing `lerna run build --scope 'app-*'` script).
- The `build-apps` job uploads its own artifact (`app-build-artifacts`) containing the built output of each app (`app-angular/dist`, `app-react/build`, `app-nextjs/.next`).
- Threaded the new `app-build-artifacts-name` input/output through `main.yml` and `test.yml` so downstream jobs can consume it.
- `apps-e2e-test` and `apps-vrt-test` in `test.yml` now download the `app-build-artifacts` artifact and set `SKIP_APP_BUILD=true` when invoking Playwright, so `app-nextjs` isn't rebuilt a second and third time in the pipeline (it was previously being built once per Playwright job via `start-server.sh`).
- Updated `scripts/start-server.sh` to skip its own `pnpm run build` step when `SKIP_APP_BUILD=true` is set, since the app was already built upstream.

## Motivation

The Angular and React demo apps are not currently covered by CI at all from a build-correctness standpoint, which means dependency bumps that compile fine for the shared libraries can still merge and silently break either app. This is a structural gap that should be closed before we keep merging dependency-bump PRs against those apps. This PR only wires up the build step; it does not add unit or E2E test coverage for `app-angular`/`app-react` (there is no test runner configured for `app-react` yet, and `app-angular`'s Karma/Jasmine unit tests aren't wired into CI either) — that's tracked as follow-up work.

## Testing

This has not yet been exercised against an actual CI run; the workflow YAML has been validated for syntax (`yaml.safe_load`) and formatting (`prettier --check`), and the underlying `pnpm run build-apps` command has been run locally against this branch to confirm it produces the expected output directories. Verifying the full pipeline (artifact upload/download, the `SKIP_APP_BUILD` short-circuit, etc.) will happen once this PR runs in GitHub Actions.

## Related

Surfaced during review of #288, #289, and #290.
