### PR TITLE
DS-2733: Fix stale ontario-task taskStatus documentation

### DIFF
--- a/packages/ontario-design-system-component-library/src/components.d.ts
+++ b/packages/ontario-design-system-component-library/src/components.d.ts
@@ -3327,7 +3327,7 @@ export namespace Components {
 		 */
 		taskId: string;
 		/**
-		 * Defines the status of the task, with default set to 'NotStarted'.  Accepts values from `TaskStatus` const: `NotStarted`, `InProgress`, `Completed`, etc.
+		 * Defines the status of the task.  Falls back to the default status if not provided, or if an unrecognized value is passed.
 		 * @default TaskStatus.NotStarted
 		 */
 		taskStatus: TaskStatus;
@@ -8733,7 +8733,7 @@ declare namespace LocalJSX {
 		 */
 		taskId?: string;
 		/**
-		 * Defines the status of the task, with default set to 'NotStarted'.  Accepts values from `TaskStatus` const: `NotStarted`, `InProgress`, `Completed`, etc.
+		 * Defines the status of the task.  Falls back to the default status if not provided, or if an unrecognized value is passed.
 		 * @default TaskStatus.NotStarted
 		 */
 		taskStatus?: TaskStatus;

--- a/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task-list/readme.md
@@ -140,8 +140,8 @@ The Ontario Task List component supports server-side rendering, with a few consi
 
 ```html
 <ontario-task-list label="Your tasks" heading-level="h2">
-	<ontario-task data-task-status="Completed" />
-	<ontario-task data-task-status="Incomplete" />
+	<ontario-task data-task-status="completed" />
+	<ontario-task data-task-status="notStarted" />
 </ontario-task-list>
 ```
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/ontario-task.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/ontario-task.tsx
@@ -71,9 +71,9 @@ export class OntarioTask {
 	@Prop({ mutable: true }) hintText?: string | Hint;
 
 	/**
-	 * Defines the status of the task, with default set to 'NotStarted'.
+	 * Defines the status of the task.
 	 *
-	 * Accepts values from `TaskStatus` const: `NotStarted`, `InProgress`, `Completed`, etc.
+	 * Falls back to the default status if not provided, or if an unrecognized value is passed.
 	 */
 	@Prop() taskStatus: TaskStatus = TaskStatus.NotStarted;
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/readme.md
@@ -146,7 +146,7 @@ Example of a task with a hint.
 
 The Ontario Task component supports server-side rendering, with a few considerations:
 
-- **Task status validation:** Always pass a valid `taskStatus`. Invalid values default to `'NotStarted'` at runtime.
+- **Task status validation:** Always pass a valid `taskStatus`. Invalid values default to `'notStarted'` at runtime.
 - **Language prop:** Pass `language` explicitly during SSR.
 - **Hydrated-only language events:** Language change events only fire after hydration.
 
@@ -156,7 +156,7 @@ The Ontario Task component supports server-side rendering, with a few considerat
 <ontario-task
 	label="Confirm email"
 	task-id="confirm-email"
-	task-status="InProgress"
+	task-status="inProgress"
 	heading-level="h3"
 	language="fr"
 	hint-text="Be sure to use your work email"
@@ -185,7 +185,7 @@ For component guidance, see:
 | `language`       | `language`        | The language of the component. This is used for translations, and is by default set through event listeners checking for a language property from the header. If no language is passed, it will default to English. | `"en" \| "fr" \| undefined`                                                                | `undefined`             |
 | `link`           | `link`            | Specifies an optional link associated with the task. If provided, clicking the task will navigate to this URL.                                                                                                      | `string \| undefined`                                                                      | `undefined`             |
 | `taskId`         | `task-id`         | A unique id for the task. This is required.                                                                                                                                                                         | `string`                                                                                   | `undefined`             |
-| `taskStatus`     | `task-status`     | Defines the status of the task, with default set to 'NotStarted'. Accepts values from `TaskStatus` const: `NotStarted`, `InProgress`, `Completed`, etc.                                                             | `"cannotStartYet" \| "completed" \| "error" \| "inProgress" \| "notStarted" \| "optional"` | `TaskStatus.NotStarted` |
+| `taskStatus`     | `task-status`     | Defines the status of the task. Falls back to the default status if not provided, or if an unrecognized value is passed.                                                                                            | `"cannotStartYet" \| "completed" \| "error" \| "inProgress" \| "notStarted" \| "optional"` | `TaskStatus.NotStarted` |
 
 ## Dependencies
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-task/test/ontario-task.e2e.ts
+++ b/packages/ontario-design-system-component-library/src/components/ontario-task/test/ontario-task.e2e.ts
@@ -19,7 +19,7 @@
 
 // 	it('applies the correct task status class', async () => {
 // 		const page = await newE2EPage();
-// 		await page.setContent('<ontario-task task-id="task-3" task-status="InProgress"></ontario-task>');
+// 		await page.setContent('<ontario-task task-id="task-3" task-status="inProgress"></ontario-task>');
 
 // 		const element = await page.find('ontario-task');
 // 		const className = await element.getProperty('className');
@@ -28,7 +28,7 @@
 
 // 	it('displays the badge with the correct status', async () => {
 // 		const page = await newE2EPage();
-// 		await page.setContent('<ontario-task task-id="task-4" task-status="Completed"></ontario-task>');
+// 		await page.setContent('<ontario-task task-id="task-4" task-status="completed"></ontario-task>');
 
 // 		const badge = await page.find('ontario-task >>> .ontario-task__badge');
 // 		expect(badge).toBeTruthy();


### PR DESCRIPTION
## Summary

Fixes DS-2733: the `ontario-task` component's `taskStatus` documentation still described the old `TaskStatuses` enum semantics (PascalCase key names like `NotStarted`, `InProgress`) even though the underlying type was remodelled (in `c9083ac6`) to a `const` object whose valid values are camelCase runtime strings (`notStarted`, `inProgress`, etc.). This produced a JSDoc comment that directly contradicted the component's own generated `Type` column, and a hand-written SSR example that used an actually-invalid value.

## What changed

- **`ontario-task.tsx`**: the `taskStatus` `@Prop()` JSDoc no longer re-lists the accepted values — that's already fully expressed by the TS type and the Stencil-generated `Type` column in the readme, and restating it in prose is exactly what went stale here. The comment now only documents the fallback behaviour (falls back to the default on an invalid/missing value).
- **`ontario-task/readme.md`** (hand-written sections above `<!-- Auto Generated Below -->`):
  - SSR example: `task-status="InProgress"` → `task-status="inProgress"` (the old value would fail the component's own case-sensitive validator and silently fall back to the default at runtime).
  - Validation bullet: `'NotStarted'` → `'notStarted'`.
- **`ontario-task-list/readme.md`**: fixed a similar hand-written example using `data-task-status="Completed"` / `"Incomplete"` (the latter isn't even a valid status) → `"completed"` / `"notStarted"`.
- **`ontario-task.e2e.ts`**: fixed casing in stale **commented-out** test code while in the area (left commented, not re-enabled — re-enabling this suite is a separate decision).
- Regenerated `components.d.ts` / `readme.md` via `pnpm build-libs` to pick up the corrected JSDoc.

## Notes for reviewers

- This branch is stacked on `scott/ci/pre-flight-checks` (#300) since that PR's Stencil-drift-check work is what surfaced this bug (regenerating the previously-stale readme revealed the JSDoc/Type conflict). The diff here is scoped to just this fix; #300's changes are the CI/build.yml/pre-flight work.
- No behavioural/runtime code changed — this is documentation only.

## Testing

- `pnpm build-libs` succeeds; regenerated files verified.
- `vitest run src/components/ontario-task` — all 7 tests pass (ontario-task + ontario-task-list specs).
