### PR TITLE
Ignore corepack integrity hash in pnpm pre-flight check

### DIFF
--- a/.github/workflows/pre-flight.yml
+++ b/.github/workflows/pre-flight.yml
@@ -32,7 +32,13 @@ jobs:
           echo "monorepo_pnpm=${monorepo_pnpm}" >> "$GITHUB_OUTPUT"
           echo "docs_pnpm=${docs_pnpm}" >> "$GITHUB_OUTPUT"
 
-          if [ "$monorepo_pnpm" != "$docs_pnpm" ]; then
+          # Compare only the version, not any optional corepack-appended integrity
+          # hash (e.g. `pnpm@11.6.0+sha512....`), which `corepack use` can add to
+          # either repo's packageManager field without changing the actual version.
+          monorepo_pnpm_version="${monorepo_pnpm%%+*}"
+          docs_pnpm_version="${docs_pnpm%%+*}"
+
+          if [ "$monorepo_pnpm_version" != "$docs_pnpm_version" ]; then
             echo "::error::pnpm version mismatch — monorepo: '$monorepo_pnpm', docs repo: '$docs_pnpm'."
             echo "Update the docs repo packageManager field (and pnpm/action-setup version in its workflows) to match before the next release."
             exit 1


### PR DESCRIPTION
## Summary

Follow-up to #312. Merging that PR immediately exposed a real pnpm version mismatch on `alpha`'s release pipeline (monorepo `pnpm@11.6.0` vs docs repo `pnpm@11.10.0`), fixed via [design-system-developer-documentation-site#22](https://github.com/ongov/design-system-developer-documentation-site/pull/22).

Re-running the pipeline after that fix landed still failed — because `corepack use pnpm@11.6.0` (used to update the docs repo) appended an integrity hash: `pnpm@11.6.0+sha512.9a36...`. The pre-flight check does an exact string compare against the monorepo's plain `pnpm@11.6.0`, so it flagged a false-positive mismatch even though the pinned version is identical.

Filed [design-system-developer-documentation-site#23] to strip that hash from the docs repo's field, but the check itself should also tolerate this — `corepack use` can add this hash to either repo's `packageManager` field at any time without an actual version change. This PR makes the comparison ignore anything after `+` on both sides.

## Test plan
- Verified the `${var%%+*}` shell parameter expansion strips a `+sha512...` suffix while leaving a plain `pnpm@X.Y.Z` string untouched.
- Will confirm in CI: pre-flight passes once both this and the docs repo hash-strip PR are merged.

Will flow back to `develop` via the normal `master` merge-back once this release cycle completes — no separate develop port needed.
