### PR TITLE
Bump packageManager pnpm to 11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,5 @@
 		"@nrwl/nx-win32-x64-msvc": "15.9.3",
 		"bl": "^7.0.0"
 	},
-	"packageManager": "pnpm@11.6.0"
+	"packageManager": "pnpm@11.10.0"
 }


### PR DESCRIPTION
## Summary

`alpha` was still pinned to `pnpm@11.6.0`. `develop` already moved to `pnpm@11.10.0` (via `c65cd6fa fix(deps): update all non-major dependencies`), and the docs site had already been bumped to `11.10.0` to track it.

The pnpm pre-flight check added in #300/#312 correctly caught this mismatch — but we initially fixed it backwards, pulling the docs repo down to match `alpha`'s stale version (design-system-developer-documentation-site#22/#23, now reverted in design-system-developer-documentation-site#24). This PR is the actual fix: bump `alpha` forward to `11.10.0` to match `develop` and the docs site.

## Test plan
- `pnpm install --frozen-lockfile` installs cleanly at `pnpm@11.10.0` against the existing lockfile (same `lockfileVersion: '9.0'` as develop) — no drift.
- Will confirm in CI that the pre-flight check now passes against the docs site's `11.10.0`.

Related: #300, #312, #313, design-system-developer-documentation-site#24