### PR TITLE
Tolerate expected core-js ignored-builds failure in docs install

### DIFF
--- a/.github/workflows/sync-docs-to-docusaurus.yml
+++ b/.github/workflows/sync-docs-to-docusaurus.yml
@@ -70,7 +70,31 @@ jobs:
         # version mismatch between this monorepo and the docs repo). The subsequent
         # component-library version bump below is a separate, intentional lockfile
         # mutation and is unaffected by --frozen-lockfile here.
-        run: pnpm install --frozen-lockfile --lockfile-dir . --ignore-workspace
+        #
+        # `--ignore-workspace` is required here -- `packages/docusaurus` matches this
+        # monorepo's own `packages/*` workspace glob, so without it pnpm would try to
+        # fold the docs repo's checkout into this monorepo's workspace. The tradeoff:
+        # `--ignore-workspace` also disables the docs repo's own `pnpm-workspace.yaml`
+        # (where its `allowBuilds` list lives), so pnpm always reports its two
+        # intentionally-denied, notice-only postinstall scripts (`core-js`,
+        # `core-js-pure`) as unapproved and exits non-zero, even though the install
+        # itself completes successfully. Tolerate exactly that known, harmless
+        # condition; anything else still fails the step.
+        run: |
+          set +e
+          output="$(pnpm install --frozen-lockfile --lockfile-dir . --ignore-workspace 2>&1)"
+          exit_code=$?
+          set -e
+          echo "$output"
+
+          if [ "$exit_code" -ne 0 ]; then
+            if [ "$(grep -c '\[ERR_PNPM_' <<< "$output")" -eq 1 ] && \
+              grep -qE '^\[ERR_PNPM_IGNORED_BUILDS\] Ignored build scripts: core-js-pure@[0-9.]+, core-js@[0-9.]+$' <<< "$output"; then
+              echo '::warning::Ignoring the expected ERR_PNPM_IGNORED_BUILDS for core-js/core-js-pure (notice-only postinstall scripts, already denied in the docs repo pnpm-workspace.yaml). See sync-docs-to-docusaurus.yml for details.'
+            else
+              exit "$exit_code"
+            fi
+          fi
 
       - name: Clean Docusaurus docs (preserve _category_.json; delete empty dirs)
         shell: bash


### PR DESCRIPTION
## Summary

Follow-up to #314. Bumping alpha's pnpm to `11.10.0` fixed the pre-flight version mismatch, but the release pipeline then failed one stage later, in `Sync Docs to Docusaurus`'s "Install Docusaurus dependencies" step, with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: core-js-pure@3.43.0, core-js@3.43.0
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 11.10.0 hard-fails an install whenever any dependency's build script is ignored, even when that denial was made intentionally via `pnpm-workspace.yaml`'s `allowBuilds` list (both this monorepo and the docs repo explicitly set `core-js`/`core-js-pure` to `false`).

The docs install step uses `--ignore-workspace`, which is required — `packages/docusaurus` matches this monorepo's own `packages: - 'packages/*'` glob, so without it pnpm tries to fold the docs checkout into this monorepo's workspace. The tradeoff, confirmed by testing locally: `--ignore-workspace` disables reading `pnpm-workspace.yaml` entirely (not just ancestor lookup), including `allowBuilds`. There's no CLI flag, env var, or global-config equivalent for `onlyBuiltDependencies`/`allowBuilds` — it's workspace-file-only. So pnpm always reports these two intentionally-denied, notice-only postinstall scripts (verified they just print a donation message) as unapproved and exits non-zero, even though the install itself completes successfully (all 1348 packages resolved and linked).

This PR tolerates exactly that known, harmless failure signature; any other pnpm error still fails the step as before.

## Test plan
- Reproduced the exact failure locally against the docs repo with pnpm 11.10.0.
- Verified the tolerant script exits 0 for the known `core-js`/`core-js-pure` ignored-builds case.
- Verified the same script still exits non-zero (propagates failure) when a different/unrelated pnpm error is present.

Related: #300, #312, #313, #314