### PR TITLE
Fix semantic-release/github crash from bogus Renovate issue references

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
 		"@nrwl/nx-win32-x64-msvc": "15.9.3",
 		"bl": "^7.0.0"
 	},
-	"packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8"
+	"packageManager": "pnpm@11.10.0"
 }

--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
 		"@nrwl/nx-win32-x64-msvc": "15.9.3",
 		"bl": "^7.0.0"
 	},
-	"packageManager": "pnpm@11.10.0"
+	"packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8"
 }

--- a/patches/@semantic-release__github@12.0.9.patch
+++ b/patches/@semantic-release__github@12.0.9.patch
@@ -1,0 +1,117 @@
+diff --git a/lib/success.js b/lib/success.js
+index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183654af40f 100644
+--- a/lib/success.js
++++ b/lib/success.js
+@@ -78,10 +78,20 @@ export default async function success(pluginConfig, context, { Octokit }) {
+     // Get associatedPRs
+     const associatedPRs = await inChunks(shas, 100, async (chunk) => {
+       const responsePRs = [];
+-      const { repository } = await octokit.graphql(
+-        buildAssociatedPRsQuery(chunk),
+-        { owner, repo },
+-      );
++      let repository;
++      try {
++        ({ repository } = await octokit.graphql(
++          buildAssociatedPRsQuery(chunk),
++          { owner, repo },
++        ));
++      } catch (error) {
++        logger.error(
++          "Failed to resolve associated pull requests for commits %O: %s",
++          chunk,
++          error.message,
++        );
++        return responsePRs;
++      }
+       const responseAssociatedPRs = Object.values(repository).map(
+         (item) => item.associatedPullRequests,
+       );
+@@ -118,26 +128,35 @@ export default async function success(pluginConfig, context, { Octokit }) {
+     const uniqueAssociatedPRs = uniqBy(flatten(associatedPRs), "number");
+ 
+     const prs = await pFilter(uniqueAssociatedPRs, async ({ number }) => {
+-      const commits = await octokit.paginate(
+-        "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
+-        {
+-          owner,
+-          repo,
+-          pull_number: number,
+-        },
+-      );
+-      const matchingCommit = commits.find(({ sha }) => shas.includes(sha));
+-      if (matchingCommit) return matchingCommit;
+-
+-      const { data: pullRequest } = await octokit.request(
+-        "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+-        {
+-          owner,
+-          repo,
+-          pull_number: number,
+-        },
+-      );
+-      return shas.includes(pullRequest.merge_commit_sha);
++      try {
++        const commits = await octokit.paginate(
++          "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
++          {
++            owner,
++            repo,
++            pull_number: number,
++          },
++        );
++        const matchingCommit = commits.find(({ sha }) => shas.includes(sha));
++        if (matchingCommit) return matchingCommit;
++
++        const { data: pullRequest } = await octokit.request(
++          "GET /repos/{owner}/{repo}/pulls/{pull_number}",
++          {
++            owner,
++            repo,
++            pull_number: number,
++          },
++        );
++        return shas.includes(pullRequest.merge_commit_sha);
++      } catch (error) {
++        logger.error(
++          "Failed to verify pull request #%d, skipping it: %s",
++          number,
++          error.message,
++        );
++        return false;
++      }
+     });
+ 
+     debug(
+@@ -173,10 +192,27 @@ export default async function success(pluginConfig, context, { Octokit }) {
+ 
+       // Get relatedIssues (or relatedPRs i.e. Issues/PRs that are closed by an associatedPR)
+       issues = await inChunks(uniqueParsedIssues, 100, async (chunk) => {
+-        const { repository } = await octokit.graphql(
+-          buildRelatedIssuesQuery(chunk.map((issue) => issue.number)),
+-          { owner, repo },
+-        );
++        let repository;
++        try {
++          ({ repository } = await octokit.graphql(
++            buildRelatedIssuesQuery(chunk.map((issue) => issue.number)),
++            { owner, repo },
++          ));
++        } catch (error) {
++          // A parsed "closes #N" reference may point at an issue/PR number
++          // that doesn't actually exist (e.g. a Renovate-escaped `&#8203;`
++          // zero-width-space HTML entity misidentified as an issue
++          // reference by the commit-message parser). GraphQL returns a
++          // top-level error for the whole query in that case, so we can't
++          // tell which alias failed - log and skip this whole chunk rather
++          // than crashing the release.
++          logger.error(
++            "Failed to resolve related issues/PRs for %O, skipping: %s",
++            chunk.map((issue) => issue.number),
++            error.message,
++          );
++          return [];
++        }
+         const responseRelatedIssues = Object.values(repository).map(
+           (issue) => issue,
+         );

--- a/patches/conventional-changelog-angular@8.0.0.patch
+++ b/patches/conventional-changelog-angular@8.0.0.patch
@@ -1,0 +1,81 @@
+diff --git a/src/templates/commit.hbs b/src/templates/commit.hbs
+index e10a0d90127ccede198df1c1959e1e14ca96fe40..2ae592ccb368209185cc3f1caa3f8c8108ce45db 100644
+--- a/src/templates/commit.hbs
++++ b/src/templates/commit.hbs
+@@ -24,38 +24,47 @@
+ {{~/if}}
+ 
+ {{~!-- commit references --}}
+-{{~#if references~}}
+-  , closes
+-  {{~#each references}} {{#if @root.linkReferences~}}
+-    [
+-    {{~#if this.owner}}
+-      {{~this.owner}}/
+-    {{~/if}}
+-    {{~this.repository}}#{{this.issue}}](
+-    {{~#if @root.repository}}
+-      {{~#if @root.host}}
+-        {{~@root.host}}/
++{{~!-- Only render ", closes #N" for references that actually matched a real
++  close/fix/resolve keyword (this.action). Without this guard, any bare
++  "#<digits>" text in a commit body/footer with no adjacent action keyword
++  still gets recorded as a reference with action: null (upstream parser
++  behaviour), and was previously rendered here as a spurious "closes #N"
++  regardless. This is what allowed Renovate's constant "&#8203;" escape
++  (used to prevent GitHub from pinging non-existent @scope users) to be
++  misread as "closes #8203" in generated changelogs/release notes. --}}
++{{~#each references}}
++  {{~#if this.action}}
++    , closes {{#if @root.linkReferences~}}
++      [
++      {{~#if this.owner}}
++        {{~this.owner}}/
+       {{~/if}}
+-      {{~#if this.repository}}
+-        {{~#if this.owner}}
+-          {{~this.owner}}/
++      {{~this.repository}}#{{this.issue}}](
++      {{~#if @root.repository}}
++        {{~#if @root.host}}
++          {{~@root.host}}/
+         {{~/if}}
+-        {{~this.repository}}
++        {{~#if this.repository}}
++          {{~#if this.owner}}
++            {{~this.owner}}/
++          {{~/if}}
++          {{~this.repository}}
++        {{~else}}
++          {{~#if @root.owner}}
++            {{~@root.owner}}/
++          {{~/if}}
++            {{~@root.repository}}
++          {{~/if}}
+       {{~else}}
+-        {{~#if @root.owner}}
+-          {{~@root.owner}}/
+-        {{~/if}}
+-          {{~@root.repository}}
+-        {{~/if}}
++        {{~@root.repoUrl}}
++      {{~/if}}/
++      {{~@root.issue}}/{{this.issue}})
+     {{~else}}
+-      {{~@root.repoUrl}}
+-    {{~/if}}/
+-    {{~@root.issue}}/{{this.issue}})
+-  {{~else}}
+-    {{~#if this.owner}}
+-      {{~this.owner}}/
++      {{~#if this.owner}}
++        {{~this.owner}}/
++      {{~/if}}
++      {{~this.repository}}#{{this.issue}}
+     {{~/if}}
+-    {{~this.repository}}#{{this.issue}}
+-  {{~/if}}{{/each}}
+-{{~/if}}
++  {{~/if}}
++{{~/each}}
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@semantic-release/github@12.0.9': 826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd
+  conventional-changelog-angular@8.0.0: 9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa
+
 importers:
   .:
     devDependencies:
@@ -27,7 +31,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.2(typescript@6.0.3))
       '@semantic-release/github':
         specifier: 12.0.9
-        version: 12.0.9(semantic-release@25.0.2(typescript@6.0.3))
+        version: 12.0.9(patch_hash=826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd)(semantic-release@25.0.2(typescript@6.0.3))
       '@semantic-release/npm':
         specifier: ^13.1.1
         version: 13.1.1(semantic-release@25.0.2(typescript@6.0.3))
@@ -212,7 +216,7 @@ importers:
         version: 2.4.1
       next:
         specifier: 15.5.20
-        version: 15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+        version: 15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -228,7 +232,7 @@ importers:
         version: 1.61.1
       '@stencil/ssr':
         specifier: ^0.4.0
-        version: 0.4.0(next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
+        version: 0.4.0(next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.2
@@ -17056,7 +17060,7 @@ snapshots:
 
   '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.2(typescript@6.0.3))':
     dependencies:
-      conventional-changelog-angular: 8.0.0
+      conventional-changelog-angular: 8.0.0(patch_hash=9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa)
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
@@ -17122,7 +17126,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/github@12.0.9(semantic-release@25.0.2(typescript@6.0.3))':
+  '@semantic-release/github@12.0.9(patch_hash=826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd)(semantic-release@25.0.2(typescript@6.0.3))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -17167,7 +17171,7 @@ snapshots:
 
   '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.2(typescript@6.0.3))':
     dependencies:
-      conventional-changelog-angular: 8.0.0
+      conventional-changelog-angular: 8.0.0(patch_hash=9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa)
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
@@ -17291,14 +17295,14 @@ snapshots:
       '@stencil/core': 4.36.2
       sass-embedded: 1.93.2
 
-  '@stencil/ssr@0.4.0(next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))':
+  '@stencil/ssr@0.4.0(next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))':
     dependencies:
       ast-types: 0.14.2
       decamelize: 6.0.0
       esbuild: 0.25.3
       imports-loader: 5.0.0(webpack@5.106.2(esbuild@0.28.1))
       mlly: 1.7.4
-      next: 15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       recast: 0.23.11
       vite: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       webpack: 5.106.2(esbuild@0.28.1)
@@ -18750,7 +18754,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-angular@8.0.0:
+  conventional-changelog-angular@8.0.0(patch_hash=9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa):
     dependencies:
       compare-func: 2.0.0
 
@@ -22126,7 +22130,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
+  next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
       '@next/env': 15.5.20
       '@swc/helpers': 0.5.15
@@ -23913,7 +23917,7 @@ snapshots:
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
-      conventional-changelog-angular: 8.0.0
+      conventional-changelog-angular: 8.0.0(patch_hash=9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa)
       conventional-changelog-writer: 8.0.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
       lerna: 9.0.7(@types/node@24.12.2)(babel-plugin-macros@3.1.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,6 @@ allowBuilds:
   puppeteer: false
   sharp: false
   unrs-resolver: false
+patchedDependencies:
+  '@semantic-release/github@12.0.9': patches/@semantic-release__github@12.0.9.patch
+  conventional-changelog-angular@8.0.0: patches/conventional-changelog-angular@8.0.0.patch


### PR DESCRIPTION
## Summary

Fixes the `Publish Packages` job failure seen on [run 30281151214](https://github.com/ongov/ontario-design-system/actions/runs/30281151214/job/90029869964) (the `chore(release): 9.0.0` release), where the job failed with:

```
Error: Could not resolve to an issue or pull request with the number of 8203
```

despite npm publish and the GitHub release already succeeding. This was cosmetic-but-blocking: it failed CI and skipped downstream jobs (`Sync Docs to Docusaurus`, `Enable Docs Auto-Merge`).

## Root cause chain

1. Renovate always HTML-entity-escapes scoped package names in PR bodies/commit messages as the literal string `&#8203;` (e.g. `@&#8203;ngx-translate/http-loader`), to stop GitHub from auto-pinging a nonexistent `@ngx-translate` user. That literal string always contains the substring `#8203`.
2. `conventional-commits-parser`'s per-line reference scanning (used transitively via `conventional-changelog-angular`, which `@semantic-release/commit-analyzer`, `@semantic-release/release-notes-generator`, and `semantic-release-lerna`'s own notes generator all depend on) records **any** bare `#<digits>` as a reference — tagged `action: null` — whenever a line doesn't contain an actual close/fix/resolve keyword immediately adjacent. This is by-design fallback behaviour in the parser (needed elsewhere for passive "see #123" style mentions).
3. `conventional-changelog-angular`'s `commit.hbs` template renders `, closes #N` for **every** entry in `references`, without checking whether `action` was ever set — so the `action: null` entry for `#8203` still got rendered as `, closes #8203` in the generated release notes/changelog.
4. `@semantic-release/git`'s commit message template (`chore(release): ${nextRelease.version}\n\n${nextRelease.notes}`) bakes that polluted notes text verbatim into the real `chore(release): X.Y.Z` commit.
5. On the *next* release run, `issue-parser` (used by `@semantic-release/github`, which has a stricter, correct keyword-adjacency regex) now finds a legitimate-looking `closes #8203` in that prior release commit's own message, and passes `{ number: 8203 }` into `@semantic-release/github`'s `success.js`, which has **no error handling** around its GraphQL/REST lookups — so GitHub's "could not resolve" error crashes the whole `success` step and the job.

This already happened once silently on `9.0.0-alpha.1` (June 25) before recurring on the real `v9.0.0` release, and is self-perpetuating on every Renovate PR for a scoped package.

Confirmed as a real, unfixed upstream bug: [semantic-release/github#1092](https://github.com/semantic-release/github/issues/1092) (open, filed Aug 2025, same failure class — an unresolvable issue/PR reference crashing an already-successful `success` step).

## Fix

Two `pnpm patch`es, following the repo's existing precedent (`patches/@semantic-release__github@12.0.2.patch`, removed in `ae508eae` once a related bug in the same file was fixed upstream in v12.0.3):

1. **`patches/@semantic-release__github@12.0.9.patch`** — wraps the three unguarded network calls in `lib/success.js` (associated-PRs GraphQL query, PR-verification `pFilter` block, related-issues GraphQL query) in `try/catch`. A single unresolvable reference now logs a warning and is skipped instead of crashing the whole job. (Defense in depth / resilience fix.)
2. **`patches/conventional-changelog-angular@8.0.0.patch`** — fixes `src/templates/commit.hbs` to only render `, closes #N` when the reference's `action` is a real close/fix/resolve keyword, not for every parsed reference. Stops the bogus text from ever being generated in the first place. (Root-cause fix.)

## Verification

- Extracted the real Renovate commit (`036fd71`) and release commit (`a565767`) text from `master` history and ran them through the actual installed `conventional-commits-parser` / `conventional-changelog-writer` / patched `commit.hbs` — confirmed the `#8203` reference (`action: null`) no longer renders `, closes #8203`, while a real `closes #42`-style reference still renders correctly.
- `node --check` on both patched files.
- `pnpm install --frozen-lockfile` succeeds cleanly after `patch-commit`.

## Follow-up (not addressed here)

The already-poisoned `chore(release): 9.0.0` commit/tag on `master` contains the literal "closes #8203" text, but this is self-limiting: future semantic-release runs only analyze commits *after* the last release tag, so it won't be re-scanned. No cleanup action is planned unless it resurfaces.
