### PR TITLE
Fix `summary-list` developer docs examples not rendering `summary-list-item`

### DIFF
--- a/packages/ontario-design-system-component-library/src/components/ontario-summary-list/readme.md
+++ b/packages/ontario-design-system-component-library/src/components/ontario-summary-list/readme.md
@@ -1,4 +1,4 @@
-import { OntarioSummaryList } from '@ongov/ontario-design-system-component-library-react';
+import { OntarioSummaryList, OntarioSummaryListItem } from '@ongov/ontario-design-system-component-library-react';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -84,6 +84,8 @@ Minimal `captionActionLink` usage. Passing only `href` uses the default localize
 		headingLevel="h3"
 		captionActionLink={{ href: '/step/contact' }}
 	>
+		<OntarioSummaryListItem name="Email" description="gsmith@gmail.com" />
+		<OntarioSummaryListItem name="Phone number" description="123-456-7890" />
 	</OntarioSummaryList>
 </div>
 
@@ -156,6 +158,8 @@ Full `captionActionLink` usage. Passing `{ href, label }` overrides the visible 
 		headingLevel="h3"
 		captionActionLink={{ href: '/step/personal-info', label: 'Update' }}
 	>
+		<OntarioSummaryListItem name="Last name" description="Smith" />
+		<OntarioSummaryListItem name="First name" description="George" />
 	</OntarioSummaryList>
 </div>
 


### PR DESCRIPTION
## Summary
The live demo examples in the summary list documentation were not rendering the list items on the Docusaurus page.

## Changes
- Added `OntarioSummaryListItem` to the React component imports in the summary list readme
- Added the missing `<OntarioSummaryListItem>` children to the live demo code blocks for both the "Contact details" and "Personal information" examples