### PR TITLE
Stop bundling major devDependency updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,17 @@
 	],
 	"packageRules": [
 		{
-			"description": "Automerge devDependencies",
+			"description": "Automerge non-major devDependencies",
 			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
 			"groupName": "devDependencies"
+		},
+		{
+			"description": "Never automerge major devDependency updates, and keep each as its own PR instead of bundling unrelated majors together (e.g. a blocked update like typescript v7 shouldn't hold up an unrelated one like semantic-release v11)",
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["major"],
+			"automerge": false
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Splits the `devDependencies` Renovate packageRule so grouping/automerge only applies to minor/patch updates. Major devDependency updates now each get their own PR and never automerge.

## Motivation

Investigating why #318 excluded #296 surfaced a config gap: the old `devDependencies` packageRule matched **all** update types, so Renovate bundled every major devDependency bump (`typescript` v7, `@semantic-release/changelog` v7, `@semantic-release/git` v11) into a single grouped PR (#296) with automerge enabled.

`typescript@7` is currently blocked upstream — Angular 22's `@angular/compiler-cli` hard-pins `typescript: ">=6.0 <6.1"` as a peer dependency, so `ng-packagr` fails building `component-library-angular` under TS7 (confirmed: #296's `Build` check is red). That single blocked package was holding up two unrelated, safe major bumps in the same PR, and — because grouped devDependency updates automerged regardless of update type — a major could auto-merge without any deliberate review.

## Changes

- `Automerge devDependencies` rule now scoped to `matchUpdateTypes: ["minor", "patch"]`.
- New rule: major devDependency updates are never automerged and are no longer grouped, so each lands as its own PR (e.g. the next Renovate run should split #296 into separate typescript / semantic-release PRs).

## Related

- #296 (blocked: typescript v7 / Angular TS7 support)
- #318 (consolidation PR that excluded #296 for the reason above)

## Also done as part of this cleanup

Added required status checks (`Build / build` + the 5 `Test / *` jobs) to `develop` branch protection, so a failing build/test suite blocks merging/auto-merging going forward — previously no status checks were required, which is how a red build like #296's could have merged unnoticed.
