### PR TITLE
Make semantic-release github success step non-fatal (hotfix)

### DIFF
--- a/patches/@semantic-release__github@12.0.9.patch
+++ b/patches/@semantic-release__github@12.0.9.patch
@@ -1,8 +1,17 @@
 diff --git a/lib/success.js b/lib/success.js
-index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183654af40f 100644
+index 48246f29a2162ce0abc0d044112de94bab39becb..72edb4d289d19b482a6759ce04e2c02475e3afdd 100644
 --- a/lib/success.js
 +++ b/lib/success.js
-@@ -78,10 +78,20 @@ export default async function success(pluginConfig, context, { Octokit }) {
+@@ -14,7 +14,7 @@ import getReleaseLinks from "./get-release-links.js";
+ 
+ const debug = debugFactory("semantic-release:github");
+ 
+-export default async function success(pluginConfig, context, { Octokit }) {
++async function successImpl(pluginConfig, context, { Octokit }) {
+   const {
+     options: { repositoryUrl },
+     commits,
+@@ -78,13 +78,25 @@ export default async function success(pluginConfig, context, { Octokit }) {
      // Get associatedPRs
      const associatedPRs = await inChunks(shas, 100, async (chunk) => {
        const responsePRs = [];
@@ -10,12 +19,17 @@ index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183
 -        buildAssociatedPRsQuery(chunk),
 -        { owner, repo },
 -      );
+-      const responseAssociatedPRs = Object.values(repository).map(
+-        (item) => item.associatedPullRequests,
+-      );
 +      let repository;
 +      try {
-+        ({ repository } = await octokit.graphql(
++        repository = await graphqlWithPartialFallback(
++          octokit,
 +          buildAssociatedPRsQuery(chunk),
 +          { owner, repo },
-+        ));
++          logger,
++        ).then((data) => data.repository);
 +      } catch (error) {
 +        logger.error(
 +          "Failed to resolve associated pull requests for commits %O: %s",
@@ -24,10 +38,13 @@ index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183
 +        );
 +        return responsePRs;
 +      }
-       const responseAssociatedPRs = Object.values(repository).map(
-         (item) => item.associatedPullRequests,
-       );
-@@ -118,26 +128,35 @@ export default async function success(pluginConfig, context, { Octokit }) {
++      const responseAssociatedPRs = Object.values(repository)
++        .filter(Boolean)
++        .map((item) => item.associatedPullRequests);
+       for (const { nodes, pageInfo } of responseAssociatedPRs) {
+         if (nodes.length === 0) continue;
+ 
+@@ -118,26 +130,35 @@ export default async function success(pluginConfig, context, { Octokit }) {
      const uniqueAssociatedPRs = uniqBy(flatten(associatedPRs), "number");
  
      const prs = await pFilter(uniqueAssociatedPRs, async ({ number }) => {
@@ -83,7 +100,7 @@ index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183
      });
  
      debug(
-@@ -173,10 +192,27 @@ export default async function success(pluginConfig, context, { Octokit }) {
+@@ -173,12 +194,28 @@ export default async function success(pluginConfig, context, { Octokit }) {
  
        // Get relatedIssues (or relatedPRs i.e. Issues/PRs that are closed by an associatedPR)
        issues = await inChunks(uniqueParsedIssues, 100, async (chunk) => {
@@ -91,20 +108,21 @@ index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183
 -          buildRelatedIssuesQuery(chunk.map((issue) => issue.number)),
 -          { owner, repo },
 -        );
+-        const responseRelatedIssues = Object.values(repository).map(
+-          (issue) => issue,
 +        let repository;
 +        try {
-+          ({ repository } = await octokit.graphql(
++          repository = await graphqlWithPartialFallback(
++            octokit,
 +            buildRelatedIssuesQuery(chunk.map((issue) => issue.number)),
 +            { owner, repo },
-+          ));
++            logger,
++          ).then((data) => data.repository);
 +        } catch (error) {
-+          // A parsed "closes #N" reference may point at an issue/PR number
-+          // that doesn't actually exist (e.g. a Renovate-escaped `&#8203;`
-+          // zero-width-space HTML entity misidentified as an issue
-+          // reference by the commit-message parser). GraphQL returns a
-+          // top-level error for the whole query in that case, so we can't
-+          // tell which alias failed - log and skip this whole chunk rather
-+          // than crashing the release.
++          // A parsed close reference can point at an issue/PR number that
++          // doesn't exist (e.g. Renovate's `&#8203;` HTML entity), and
++          // GraphQL gave us nothing usable to recover from - skip this
++          // chunk instead of crashing the release.
 +          logger.error(
 +            "Failed to resolve related issues/PRs for %O, skipping: %s",
 +            chunk.map((issue) => issue.number),
@@ -112,6 +130,76 @@ index 48246f29a2162ce0abc0d044112de94bab39becb..e106ddf9ba078c9f75ef06ef1c358183
 +          );
 +          return [];
 +        }
-         const responseRelatedIssues = Object.values(repository).map(
-           (issue) => issue,
++        const responseRelatedIssues = Object.values(repository).filter(
++          Boolean,
          );
+         return buildIssuesOrPRsFromResponseNode(responseRelatedIssues);
+       });
+@@ -332,6 +369,32 @@ export default async function success(pluginConfig, context, { Octokit }) {
+   }
+ }
+ 
++/**
++ * By the time this step runs, the release (npm publish + GitHub release/tag)
++ * has already succeeded in the "publish" step - everything below is
++ * best-effort notification (comments, labels, closing stale issues) and
++ * should never fail the CI job. Individual calls are already guarded, but
++ * this outer try/catch is the real fix: any error that still escapes is
++ * logged, not rethrown.
++ *
++ * @see https://github.com/semantic-release/github/issues/1092
++ */
++export default async function success(pluginConfig, context, options) {
++  const { logger } = context;
++  try {
++    await successImpl(pluginConfig, context, options);
++  } catch (error) {
++    const errors = error && error.errors ? error.errors : [error];
++    logger.error(
++      "The \"success\" step failed after the release had already completed successfully. Suppressing %d error(s) so they don't fail the release job:",
++      errors.length,
++    );
++    for (const err of errors) {
++      logger.error(" - %s", (err && err.message) || err);
++    }
++  }
++}
++
+ /**
+  * In order to speed up a function call that handles a big array of items, we split up the
+  * array in chunks and call the function for each chunk in parallel. At the end we combine the
+@@ -354,6 +417,34 @@ async function inChunks(items, chunkSize, callback) {
+   return results.flat();
+ }
+ 
++/**
++ * Runs a GraphQL query that aliases one field per item in a batch (e.g. one
++ * commit or issue number per alias) and tolerates individual aliases failing
++ * to resolve (e.g. a bogus issue/PR number) without losing the rest of the
++ * batch. GraphQL only nulls out the failing (nullable) field and still
++ * returns the sibling aliases, so on error we fall back to that partial
++ * `error.data` instead of treating the whole batch as failed.
++ *
++ * Rethrows if there's no usable partial data at all (e.g. a network error,
++ * or every alias in the batch failed), leaving it to the caller to decide
++ * how to handle a total failure.
++ */
++async function graphqlWithPartialFallback(octokit, query, variables, logger) {
++  try {
++    return await octokit.graphql(query, variables);
++  } catch (error) {
++    const partialData = error.data;
++    if (!partialData?.repository) {
++      throw error;
++    }
++    logger.error(
++      "Some references in this batch failed to resolve, continuing with the rest: %s",
++      error.message,
++    );
++    return partialData;
++  }
++}
++
+ /**
+  * Fields common accross PRs and Issue
+  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@semantic-release/github@12.0.9': 826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd
+  '@semantic-release/github@12.0.9': 5946a9b3da3b40f6ef0639eb57fb67fa27a675dcfb85c8183dde88ac9542542d
   conventional-changelog-angular@8.0.0: 9ac24139b82ad3e25555c1e04b46d9fab38c7ad72cff37147c63e61f83e7d6aa
 
 importers:
@@ -31,7 +31,7 @@ importers:
         version: 10.0.1(semantic-release@25.0.2(typescript@6.0.3))
       '@semantic-release/github':
         specifier: 12.0.9
-        version: 12.0.9(patch_hash=826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd)(semantic-release@25.0.2(typescript@6.0.3))
+        version: 12.0.9(patch_hash=5946a9b3da3b40f6ef0639eb57fb67fa27a675dcfb85c8183dde88ac9542542d)(semantic-release@25.0.2(typescript@6.0.3))
       '@semantic-release/npm':
         specifier: ^13.1.1
         version: 13.1.1(semantic-release@25.0.2(typescript@6.0.3))
@@ -17126,7 +17126,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/github@12.0.9(patch_hash=826e5cbb6700db04222c040149bc19773d1fa6dd4429938ea7080b63e0fca2dd)(semantic-release@25.0.2(typescript@6.0.3))':
+  '@semantic-release/github@12.0.9(patch_hash=5946a9b3da3b40f6ef0639eb57fb67fa27a675dcfb85c8183dde88ac9542542d)(semantic-release@25.0.2(typescript@6.0.3))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)


### PR DESCRIPTION
## Summary

Follow-up to #323, which fixed the `Publish Packages` crash from a bogus issue reference (Renovate's `&#8203;` escape misread as `#8203` by the commit parser) by wrapping specific GraphQL/REST calls in `success.js` in try/catch.

That fix worked, but its own commit body described the bug using a close-style keyword directly in front of that same bogus number - which the strict `issue-parser` in `success.js` reads as a real close-directive. So the exact same crash recurred on the next release ([9.1.0-alpha.1](https://github.com/ongov/ontario-design-system/actions/runs/31193231134/job/92918622714)), caused by the fix's own description rather than a new bug.

As before, npm publish and the GitHub release had **already succeeded** - only the post-release PR/issue commenting-and-labelling step failed, which skipped docs sync for that release.

## Fix

Two changes:

1. **Outer safety net.** Instead of guarding more individual call sites, wrap the whole `success()` step: renamed it to `successImpl` and added a `success` entry point that runs it and logs (doesn't rethrow) anything that escapes. This step is pure best-effort notification after the release is already live - it shouldn't be able to fail CI.
2. **Partial-batch recovery.** The existing per-batch GraphQL guards (up to 100 commits/issues per query) discarded the *whole batch* on a single bad alias, silently skipping every other legitimate PR/issue in it too. GitHub's GraphQL API actually returns partial data alongside the error (only the failing alias is nulled), so a new `graphqlWithPartialFallback` helper recovers that partial data instead of losing the whole batch - only the one bad reference is skipped now.

## Notes on the diff

Regenerated properly via `pnpm patch`/`pnpm patch-commit` rather than hand-editing the `.patch` file. The patch hash in `pnpm-lock.yaml` is a plain sha256 of the patch file, so I applied just that 3-line change instead of committing an unrelated full lockfile reformat; verified with `pnpm install --frozen-lockfile` ("lockfile is up to date, resolution step is skipped").

## Test plan

- `node --check` on the patched file.
- `pnpm install --frozen-lockfile` - clean, no drift.
- Confirmed against the real GitHub GraphQL API that a batch with one bad alias (`#8203`) still returns valid sibling data (`error.data`) for the rest.
- Reproduced both scenarios against a mocked Octokit: (1) a single-alias failure now still comments/labels the other real issues/PRs in the same batch, and (2) a genuine total failure (no partial data) is still caught by the outer wrapper instead of crashing.

## Not in this PR

Manually recreating the missed success-step comments/labels for the already-shipped `9.1.0-alpha.1` release - being handled separately. The Docusaurus docs sync for that release is done in ongov/design-system-developer-documentation-site#27.

