### PR TITLE
DS-2603: Add new process for shipping css for react

### DIFF
--- a/packages/app-nextjs/custom.d.ts
+++ b/packages/app-nextjs/custom.d.ts
@@ -1,1 +1,2 @@
 declare module '*.scss';
+declare module '*.css';

--- a/packages/ontario-design-system-component-library-react/README.md
+++ b/packages/ontario-design-system-component-library-react/README.md
@@ -42,11 +42,21 @@ To use the Ontario Design System React component library, follow these steps:
 
 2. Import the theme file into your project’s entry point.
 
+   This package ships a precompiled, ready-to-use CSS file — no Sass compiler is required in your app's build pipeline:
+
    ```tsx
-   import '@ongov/ontario-design-system-component-library-react/styles';
+   import '@ongov/ontario-design-system-component-library-react/theme.css';
    ```
 
-   If you need to override the asset base path, create a local theme wrapper:
+   This resolves to a single, monolithic `theme.css` file containing the Ontario Design System's base styles, global styles, and all component styles. It is pre-built with an `/assets` base path, so it expects fonts, images, and favicons to be available at `/assets` (see [Local assets](#local-assets) below for the copy step).
+
+   > **TypeScript note:** if your project doesn't already have an ambient module declaration for `*.css` (some starter templates only declare `*.module.css`), add one to a `.d.ts` file included in your `tsconfig.json`, otherwise TypeScript will report "Cannot find module" for this side-effect import:
+   >
+   > ```ts
+   > declare module '*.css';
+   > ```
+
+   If you need to override the asset base path (for example, if you serve fonts/images/favicons from a path other than `/assets`), you'll need to compile the Sass entry point yourself instead, so the `$asset-base-path` variable can be overridden at compile time. Create a local theme wrapper:
 
    ```scss
    // src/styles/ontario-theme.scss
@@ -56,7 +66,7 @@ To use the Ontario Design System React component library, follow these steps:
    );
    ```
 
-   Then import that wrapper in your app entry point.
+   Then import that wrapper in your app entry point, and make sure your bundler is configured to compile Sass (see [Next.js usage](#nextjs-usage) below for the `pkg:` resolution helper needed in that case).
 
 3. Configure the asset path (recommended when assets are not served from `/`).
 
@@ -94,9 +104,13 @@ Components can be improted directly:
 
 ### Next.js usage
 
+The recommended path for most Next.js apps is to import the precompiled `theme.css` (see step 2 above) — no Sass configuration is required for this path, including with Turbopack.
+
+The steps below (particularly the `pkg:` Sass resolution config) are only needed if you're compiling the Sass entry point yourself, for example to override `$asset-base-path`.
+
 When using this package with Next.js App Router, three additional steps are recommended:
 
-1. Configure Next.js for SSR and Sass `pkg:` support
+1. Configure Next.js for SSR and Sass `pkg:` support (only needed if compiling Sass yourself)
 
    Create or update `next.config.mjs` to include the following:
 
@@ -126,6 +140,8 @@ When using this package with Next.js App Router, three additional steps are reco
 
    The `pkgImporter` helper adds this support by resolving `pkg:` specifiers to the correct Sass files in `node_modules`.
 
+   If you're importing the precompiled `theme.css` instead (the default recommended path), skip this step — `pkg:` resolution is only relevant when compiling Sass.
+
 2. Import theme styles
 
    ```scss
@@ -148,12 +164,14 @@ When using this package with Next.js App Router, three additional steps are reco
 
 <hr />
 
-### Sass (optional)
+### Sass (optional, only needed for customization)
 
-If you use Sass and want `pkg:` resolution via `@use`, import the styles entry point:
+Most consumers should use the precompiled `theme.css` described above and do not need Sass at all — this avoids the `sass`/`sass-embedded` `pkg:` importer workaround entirely.
+
+If you need to customize the theme at compile time (for example, overriding `$asset-base-path`, or building your own modular subset of styles), you can still consume the Sass source directly:
 
 ```scss
-@use 'pkg:@ongov/ontario-design-system-component-library-react/styles' as ods;
+@use 'pkg:@ongov/ontario-design-system-component-library-react/styles/theme.scss' as ods;
 ```
 
 ### Local assets

--- a/packages/ontario-design-system-component-library-react/package.json
+++ b/packages/ontario-design-system-component-library-react/package.json
@@ -14,7 +14,7 @@
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"type": "module",
-	"styles": "./dist/styles/theme.scss",
+	"styles": "./dist/styles/theme.css",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
@@ -40,9 +40,9 @@
 			"default": "./dist/react-component-lib/index.js"
 		},
 		"./package.json": "./package.json",
-		"./styles": {
-			"default": "./dist/styles/theme.scss"
-		},
+		"./styles": "./dist/styles/theme.css",
+		"./styles/theme.scss": "./dist/styles/theme.scss",
+		"./theme.css": "./dist/styles/theme.css",
 		"./styles/*": "./dist/styles/*"
 	},
 	"files": [
@@ -54,7 +54,8 @@
 	],
 	"scripts": {
 		"build": "pnpm run clean && pnpm run compile && pnpm run docs:copy:readme && pnpm run docs:copy:docs",
-		"postbuild": "pnpm run copy:assets",
+		"postbuild": "pnpm run copy:assets && pnpm run build:css",
+		"build:css": "node ./scripts/build-css.mjs",
 		"clean": "rm -rf dist",
 		"clean:full": "rm -rf node_modules && pnpm run clean",
 		"compile": "pnpm run tsc",
@@ -82,6 +83,7 @@
 		"prettier": "^3.4.2",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
+		"sass-embedded": "^1.93.2",
 		"typescript": "^6.0.0"
 	},
 	"peerDependencies": {

--- a/packages/ontario-design-system-component-library-react/scripts/build-css.mjs
+++ b/packages/ontario-design-system-component-library-react/scripts/build-css.mjs
@@ -1,0 +1,67 @@
+import { compile, compileString } from 'sass-embedded';
+import { NodePackageImporter } from 'sass-embedded';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+/**
+ * Compiles the Ontario Design System theme Sass entry point into a single,
+ * distributable CSS file.
+ *
+ * This is a monolithic output (one `theme.css` containing base styles, global
+ * styles, and all component styles) chosen as the initial CSS output strategy
+ * so that Next.js (and other) consumers can `import` a ready-to-use stylesheet
+ * without needing a Sass compiler configured in their own build pipeline.
+ *
+ * The `NodePackageImporter` is required here because the copied `theme.scss`
+ * entry point uses `pkg:` specifiers (e.g. `pkg:@ongov/ontario-design-system-global-styles/...`)
+ * to resolve styles from sibling workspace packages.
+ *
+ * `$asset-base-path` is explicitly overridden to `/assets` here, matching the
+ * asset-copying convention documented in this package's README (consumers are
+ * instructed to copy `dist/assets/*` into their app's `public/assets` folder).
+ * The Sass default for this variable (`../../..`) is a *relative* path meant
+ * for the source repo's own folder structure, and does not resolve correctly
+ * once the styles are precompiled and consumed from an arbitrary app's public
+ * directory — so without this override, font/image `url()` references in the
+ * compiled CSS would 404 in a consuming app.
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+
+const input = path.join(packageRoot, 'dist/styles/theme.scss');
+const outDir = path.join(packageRoot, 'dist/styles');
+const outFile = path.join(outDir, 'theme.css');
+
+const DEFAULT_ASSET_BASE_PATH = '/assets';
+
+async function buildCss() {
+	// Compile a small synthetic entry point that forwards the real theme.scss
+	// while overriding `$asset-base-path`, rather than compiling theme.scss
+	// directly, so the resulting CSS contains asset URLs that work out of the
+	// box for consumers following the documented asset-copying convention.
+	const entrySource = `@forward "${input.replace(/\\/g, '\\\\')}" with ($asset-base-path: "${DEFAULT_ASSET_BASE_PATH}");\n`;
+
+	const result = compileString(entrySource, {
+		style: 'expanded',
+		sourceMap: true,
+		sourceMapIncludeSources: true,
+		importers: [new NodePackageImporter()],
+		url: new URL(`file://${outDir}/__theme-entry.scss`),
+	});
+
+	await mkdir(outDir, { recursive: true });
+	await writeFile(outFile, result.css, 'utf8');
+
+	if (result.sourceMap) {
+		await writeFile(`${outFile}.map`, JSON.stringify(result.sourceMap), 'utf8');
+	}
+
+	console.log(`[build-css] Compiled ${path.relative(packageRoot, input)} -> ${path.relative(packageRoot, outFile)}`);
+	console.log(`[build-css] Asset base path baked into output: ${DEFAULT_ASSET_BASE_PATH}`);
+}
+
+buildCss().catch((error) => {
+	console.error('[build-css] Failed to compile theme CSS:', error);
+	process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,7 +168,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 22.0.5
-        version: 22.0.5(b3a9e494b0e3478e8b594b812739d4ef)
+        version: 22.0.5(d0bcb0394f09e87ca18ede4742f7a59c)
       '@angular/cli':
         specifier: ~22.0.0
         version: 22.0.0(@types/node@24.12.2)(chokidar@5.0.0)
@@ -216,7 +216,7 @@ importers:
         version: 2.4.1
       next:
         specifier: 15.5.20
-        version: 15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+        version: 15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -232,7 +232,7 @@ importers:
         version: 1.61.1
       '@stencil/ssr':
         specifier: ^0.4.0
-        version: 0.4.0(next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
+        version: 0.4.0(next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.2
@@ -501,7 +501,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 22.0.5
-        version: 22.0.5(d0bcb0394f09e87ca18ede4742f7a59c)
+        version: 22.0.5(b3a9e494b0e3478e8b594b812739d4ef)
       '@angular/animations':
         specifier: 22.0.5
         version: 22.0.5(@angular/core@22.0.5(@angular/compiler@22.0.5)(rxjs@7.8.1)(zone.js@0.16.2))
@@ -593,6 +593,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      sass-embedded:
+        specifier: ^1.93.2
+        version: 1.93.2
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -17295,14 +17298,14 @@ snapshots:
       '@stencil/core': 4.36.2
       sass-embedded: 1.93.2
 
-  '@stencil/ssr@0.4.0(next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))':
+  '@stencil/ssr@0.4.0(next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))':
     dependencies:
       ast-types: 0.14.2
       decamelize: 6.0.0
       esbuild: 0.25.3
       imports-loader: 5.0.0(webpack@5.106.2(esbuild@0.28.1))
       mlly: 1.7.4
-      next: 15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
+      next: 15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0)
       recast: 0.23.11
       vite: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.93.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       webpack: 5.106.2(esbuild@0.28.1)
@@ -22130,7 +22133,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@15.5.20(@babel/core@7.29.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
+  next@15.5.20(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0):
     dependencies:
       '@next/env': 15.5.20
       '@swc/helpers': 0.5.15


### PR DESCRIPTION
- Right now, if a team wants to use our React components in Next.js, they also need our CSS, but we only ship Sass source files, not actual CSS. That means every team has to have Sass compiling properly in their own build, and for a lot of Next.js setups (especially with Turbopack), that just doesn't work cleanly. Some teams get stuck entirely.
- This MR fixes that by precompiling our Sass into a plain `theme.css` file and shipping it with the React package. Now teams can just do:
`import '@ongov/ontario-design-system-component-library-react/theme.css';`

**How it works**
- Added a small script that runs after our normal build and compiles the theme's Sass into real CSS.
- Along the way, I found and fixed a bug where our Sass has a variable that controls where font/image URLs point [$asset-base-path] and its default only makes sense inside our own repo. Once compiled and shipped elsewhere, those paths would've broken and fonts would 404. This was fixed by baking in the [/assets] path we already tell consumers to copy their fonts into.
- Added the new `theme.css` export to the package so it's actually importable. The old Sass path is still there too, nothing's removed, this is additive.