### PR TITLE
DS-1913: Fix mixed-language footer links in the Angular POC

### DIFF
--- a/packages/app-angular/src/app/app.component.html
+++ b/packages/app-angular/src/app/app.component.html
@@ -1,5 +1,6 @@
 <div class="ontario-container">
 	<ontario-header
+		language="{{ currentLang }}"
 		type="application"
 		[applicationHeaderInfo]="{
 			title: getTranslation().appName,
@@ -13,13 +14,13 @@
 			{
 				title: getTranslation().menuItemOne,
 				href: getRoute().home,
-				linkIsActive: getRoute().homeIsActive
+				linkIsActive: getRoute().homeIsActive,
 			},
 			{
 				title: getTranslation().menuItemTwo,
 				href: getRoute().register,
-				linkIsActive: getRoute().registerIsActive
-			}
+				linkIsActive: getRoute().registerIsActive,
+			},
 		]"
 		[customLanguageToggle]="useLanguage"
 	>
@@ -33,22 +34,6 @@
 		</div>
 	</main>
 	<div class="ontario-footer-wrapper">
-		<ontario-footer
-			type="default"
-			[footerLinks]="{
-				accessibilityLink: {
-					text: getTranslation().accessibility,
-					href: getTranslation().accessibilityLink
-				},
-				privacyLink: {
-					text: getTranslation().privacy,
-					href: getTranslation().privacyLink
-				},
-				contactLink: {
-					text: getTranslation().contactUs,
-					href: getTranslation().contactUsLink
-				}
-			}"
-		></ontario-footer>
+		<ontario-footer type="default" [language]="currentLang" [footerLinks]="footerLinks"></ontario-footer>
 	</div>
 </div>

--- a/packages/app-angular/src/app/app.component.ts
+++ b/packages/app-angular/src/app/app.component.ts
@@ -1,14 +1,13 @@
-import { Component, Renderer2, OnInit, NgZone, ChangeDetectorRef } from '@angular/core';
-import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
-import { AppConfigService } from './app-config.service';
+import { ChangeDetectorRef, Component, OnInit, NgZone } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { UrlGeneratorService } from './url-generator.service';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 
-import { getLanguage, isEnglish } from '../utils/get-language.utils';
-
 import { isAngularPOCEnvironment } from './translation.config';
+
+type AppLanguage = 'en' | 'fr';
 
 @Component({
 	selector: 'app-root',
@@ -18,25 +17,37 @@ import { isAngularPOCEnvironment } from './translation.config';
 })
 export class AppComponent implements OnInit {
 	title = 'app-angular';
-	public currentLang!: string;
+	public currentLang: AppLanguage = 'en';
+	private languageRequestId = 0;
 
 	constructor(
 		private translate: TranslateService,
-		private renderer: Renderer2,
 		private router: Router,
 		private zone: NgZone,
 		private cdr: ChangeDetectorRef,
 		private urlGenerator: UrlGeneratorService,
-		private appConfigService: AppConfigService,
 		private titleService: Title,
 	) {
 		translate.setDefaultLang('en');
-		translate.use('en');
+	}
 
-		translate.onLangChange.subscribe((event: LangChangeEvent) => {
-			this.currentLang = event.lang;
-			this.cdr.detectChanges();
-		});
+	get footerLinks() {
+		const translation = this.getTranslation();
+
+		return {
+			accessibilityLink: {
+				text: translation.accessibility,
+				href: translation.accessibilityLink,
+			},
+			privacyLink: {
+				text: translation.privacy,
+				href: translation.privacyLink,
+			},
+			contactLink: {
+				text: translation.contactUs,
+				href: translation.contactUsLink,
+			},
+		};
 	}
 
 	getTranslation() {
@@ -67,13 +78,13 @@ export class AppComponent implements OnInit {
 		};
 	}
 
-	getLanguageFromURL() {
+	getLanguageFromURL(): AppLanguage {
 		return window.location.hash.includes('/fr/') ? 'fr' : 'en';
 	}
 
 	getRoute() {
-		const getStarted = isEnglish() ? 'get-started' : 'fr/demarrer';
-		const register = isEnglish() ? 'create-account' : 'fr/creer-compte';
+		const getStarted = this.currentLang === 'en' ? 'get-started' : 'fr/demarrer';
+		const register = this.currentLang === 'en' ? 'create-account' : 'fr/creer-compte';
 		const homeIsActive = window.location.hash.includes(getStarted);
 		const registerIsActive = window.location.hash.includes(register);
 
@@ -85,23 +96,34 @@ export class AppComponent implements OnInit {
 		};
 	}
 
-	useLanguage = (e: any) => {
+	useLanguage = (e: Event) => {
 		e.preventDefault();
-		const lang = getLanguage();
-		this.translate.use(lang);
-		this.translate.setDefaultLang(lang);
-
-		// Manually trigger change detection
-		this.cdr.detectChanges();
-
-		// get and navigate to the translated route
-		const routes = this.translate.instant(`routes`);
-
-		this.zone.run(() => {
-			const pathname = window.location.hash.replace('#', '');
-			this.router.navigateByUrl(routes[pathname]);
-		});
+		const language: AppLanguage = this.currentLang === 'en' ? 'fr' : 'en';
+		this.setLanguage(language, true);
 	};
+
+	private setLanguage(language: AppLanguage, navigateToTranslatedRoute = false) {
+		const languageRequestId = ++this.languageRequestId;
+		this.currentLang = language;
+		// Keeps <html lang> aligned on toggle; the initial value is set in index.html before hydration.
+		document.documentElement.lang = language;
+		this.translate.setDefaultLang(language);
+
+		this.translate.use(language).subscribe(() => {
+			if (languageRequestId !== this.languageRequestId) return;
+
+			this.cdr.detectChanges();
+
+			if (navigateToTranslatedRoute) {
+				const routes = this.translate.instant('routes') as Record<string, string>;
+				const pathname = window.location.hash.replace('#', '');
+
+				this.zone.run(() => {
+					this.router.navigateByUrl(routes[pathname]);
+				});
+			}
+		});
+	}
 
 	updateTitleFromRoute() {
 		const route = this.router.routerState.snapshot.root;
@@ -123,15 +145,7 @@ export class AppComponent implements OnInit {
 	}
 
 	ngOnInit() {
-		const lang = this.getLanguageFromURL();
-
-		// Set the default language
-		this.translate.setDefaultLang(lang);
-		this.translate.use(lang);
-
-		// Update the header language prop
-		const header = document.getElementsByTagName('ontario-header')[0];
-		this.renderer.setProperty(header, 'language', lang);
+		this.setLanguage(this.getLanguageFromURL());
 
 		// Listen for route changes
 		this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {

--- a/packages/app-angular/src/index.html
+++ b/packages/app-angular/src/index.html
@@ -11,6 +11,11 @@
 		<link rel="icon" href="./assets/favicons/favicon-48x48.png" type="image/png" />
 		<link rel="icon" href="./assets/favicons/apple-touch-icon.png" type="image/png" />
 		<link rel="manifest" href="./assets/manifest.json" />
+		<script>
+			// Ontario components read <html lang> as they hydrate, which happens before Angular can
+			// set it, so the language is resolved from the URL here first.
+			document.documentElement.lang = window.location.hash.includes('/fr/') ? 'fr' : 'en';
+		</script>
 	</head>
 	<body>
 		<app-root></app-root>

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/test/ontario-footer.spec.tsx
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/test/ontario-footer.spec.tsx
@@ -57,6 +57,20 @@ describe('ontario-footer', () => {
 		expect(inlineLinks?.[2].textContent?.trim()).toBe('Contact');
 	});
 
+	it('updates default links when language changes', async () => {
+		const page = await render('<ontario-footer type="default" language="en"></ontario-footer>');
+		const footer = page.root as HTMLElement & { language: 'en' | 'fr' };
+
+		footer.language = 'fr';
+		await page.waitForChanges();
+
+		const inlineLinks = page.root?.shadowRoot?.querySelectorAll(
+			'.ontario-footer__links-container--inline .ontario-footer__link',
+		);
+		expect(inlineLinks?.[0].textContent?.trim()).toBe('Accessibilité');
+		expect(inlineLinks?.[1].textContent?.trim()).toBe('Confidentialité');
+	});
+
 	it('renders twoColoumn ontario-footer', async () => {
 		const page = await render(`
       <ontario-footer


### PR DESCRIPTION
## Summary

The ticket reported the Angular POC translating only some footer links when switching to French. Ontario components read `<html lang>` as they hydrate, and `index.html` hard-coded `lang="en"` — so on a French page the copyright line hydrated as English while the app's own links rendered in French. This PR resolves `<html lang>` from the URL before Angular bootstraps and keeps it aligned on toggle.

## Changes

- Set `<html lang>` from the URL in `index.html`, before Angular bootstraps
- Route all language switching through one `setLanguage()`, replacing the
  `onLangChange` subscription and the toggle's own logic
- Derive routes and footer links from `currentLang` instead of re-reading the URL
- Move footer links from an inline template literal into a `footerLinks` getter
- Bind `language` on `ontario-header` and `ontario-footer`
- Drop now-unused `Renderer2`, `AppConfigService` and `get-language` utils
- Add a footer regression test covering built-in links following `language`

## Scope

`app-angular` only, plus one component-library test. No component source changed.

## Verification

https://github.com/user-attachments/assets/7362dfca-43e1-4d98-94ba-54baef5686e6