### PR TITLE
DS-2013: Fix Complete Styles package not working in Angular application

### DIFF
--- a/packages/ontario-design-system-complete-styles/gulpfile.js
+++ b/packages/ontario-design-system-complete-styles/gulpfile.js
@@ -31,11 +31,21 @@ const compileSass = (input, outputFile, options) => {
 		sassOptions.sourceComments = true;
 	}
 
-	return src(input, { sourcemaps: options.sourcemaps })
-		.pipe(sass(sassOptions).on('error', sass.logError))
+	const sassStream = sass(sassOptions);
+	const outputStream = src(input, { sourcemaps: options.sourcemaps })
+		.pipe(sassStream)
 		.pipe(gulpif(options.compress, concat(`${outputFile}.min.css`), concat(`${outputFile}.css`)))
 		.pipe(gulpif(options.compress, minify()))
 		.pipe(dest(paths.output.theme, { sourcemaps: options.sourcemaps ? '.' : false }));
+
+	// gulp-sass logs compile errors but doesn't fail the pipeline by default; forward the
+	// error onto the returned stream so gulp treats a broken Sass compile as a build failure.
+	sassStream.on('error', (error) => {
+		sass.logError.call(sassStream, error);
+		outputStream.emit('error', error);
+	});
+
+	return outputStream;
 };
 
 task('clean:dist', async () => {
@@ -93,29 +103,19 @@ task('generate:components-import-file', async (done) => {
 	done();
 });
 
-task('sass:build', async (done) => {
-	try {
-		compileSass(paths.files.theme, 'ontario-theme', {
-			compress: false,
-			sourcemaps: true,
-		});
-		done();
-	} catch (error) {
-		done(error);
-	}
-});
+task('sass:build', () =>
+	compileSass(paths.files.theme, 'ontario-theme', {
+		compress: false,
+		sourcemaps: true,
+	}),
+);
 
-task('sass:minify', async (done) => {
-	try {
-		compileSass(paths.files.theme, 'ontario-theme', {
-			compress: true,
-			sourcemaps: false,
-		});
-		done();
-	} catch (error) {
-		done(error);
-	}
-});
+task('sass:minify', () =>
+	compileSass(paths.files.theme, 'ontario-theme', {
+		compress: true,
+		sourcemaps: false,
+	}),
+);
 
 task('sass:copy-dist', () => {
 	return src(paths.styles.all).pipe(dest(paths.output.styles));

--- a/packages/ontario-design-system-complete-styles/gulpfile.js
+++ b/packages/ontario-design-system-complete-styles/gulpfile.js
@@ -157,11 +157,6 @@ task('generate:index', async (done) => {
 	}
 });
 
-task('watch', (done) => {
-	watch(paths.styles.dir, { ignoreInitial: false }, parallel('sass:build-minify'));
-	done();
-});
-
 task(
 	'deploy',
 	series(
@@ -183,5 +178,26 @@ task(
 		'clean:src',
 	),
 );
+
+// `src/` is regenerated from the global-styles and component-library packages on every
+// build and deleted again at the end (see 'deploy'), so there's nothing under this
+// package's own `src/` to watch. Watch the upstream sources instead and re-run the full
+// deploy pipeline whenever they change.
+task('watch', (done) => {
+	watch(
+		[
+			paths.dsGlobalStyles.src,
+			paths.dsGlobalStyles.favicons,
+			paths.dsComponentLibrary.globalStyles,
+			paths.dsComponentLibrary.commonStyles,
+			paths.dsComponentLibrary.utils,
+			paths.dsComponentLibrary.components,
+			...paths.dsComponentLibrary.assets,
+		],
+		{ ignoreInitial: false },
+		series('deploy'),
+	);
+	done();
+});
 
 task('default', series('watch'));

--- a/packages/ontario-design-system-complete-styles/package.json
+++ b/packages/ontario-design-system-complete-styles/package.json
@@ -22,7 +22,7 @@
 		"clean": "rm -rf dist",
 		"clean:full": "rm -rf node_modules && pnpm run clean",
 		"format": "prettier --write .",
-		"scss": "sass --watch scss:css",
+		"watch": "gulp watch",
 		"docs:copy:readme": "ts-node ../../scripts/documentation-helper.ts -f README.md -p \"---\ntitle: Complete Styles\n---\n\" --df ../docusaurus/docs/06-readme-complete-styles.md"
 	},
 	"dependencies": {

--- a/packages/ontario-design-system-component-library/src/components/ontario-back-button/ontario-back-button.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-back-button/ontario-back-button.scss
@@ -3,7 +3,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/breakpoints.variables' as breakpoints;
 @use '../ontario-button/ontario-button.scss';
 
-$ontario-icon-size: 24px;
+$_ontario-icon-size: 24px;
 
 /**
 * Tertiary button defaults are overridden to achieve the mini-button specifications
@@ -26,8 +26,8 @@ $ontario-icon-size: 24px;
 	.ontario-icon {
 		margin: spacing.$spacing-0 math.div(spacing.$spacing-3, 2) spacing.$spacing-0 spacing.$spacing-0;
 		padding: spacing.$spacing-0;
-		min-width: $ontario-icon-size;
-		min-height: $ontario-icon-size;
+		min-width: $_ontario-icon-size;
+		min-height: $_ontario-icon-size;
 	}
 }
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-checkbox/ontario-checkboxes.scss
@@ -5,8 +5,8 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/colours.variables' as colours;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/breakpoints.variables' as breakpoints;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/ontario-critical-alert.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-critical-alert/ontario-critical-alert.scss
@@ -1,7 +1,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/spacing.variables' as spacing;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/colours.variables' as colours;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-weights.variables' as fontWeights;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
 
 $ontario-critical-alert-icon-size: 28px;
 $ontario-critical-alert-z-index: 10;

--- a/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-date-input/ontario-date-input.scss
@@ -2,8 +2,8 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/spacing.variables' as spacing;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-weights.variables' as fontWeights;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/global.variables' as globalVariables;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-dropdown-list/ontario-dropdown-list.scss
@@ -1,7 +1,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/spacing.variables' as spacing;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/colours.variables' as colours;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-fieldset/ontario-fieldset.scss
@@ -1,6 +1,6 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/spacing.variables' as spacing;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-footer/ontario-footer.scss
@@ -5,9 +5,9 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/breakpoints.variables' as breakpoints;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/fonts.variables' as fonts;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-weights.variables' as fontWeights;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
-@forward 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/spacing.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/spacing.overrides' as spacingOverrides;
 
 $ontario-icon-size--social-large: 36px;
 $ontario-icon-size--social-small: 32px;

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/ontario-header-menu-tabs.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-menu-tabs/ontario-header-menu-tabs.scss
@@ -11,38 +11,38 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSize;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/typography.variables';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 @use '../../styles/header.scss';
 
 // Variables
-$border-width-1: 1px;
-$border-width-2: 2px;
-$border-width-6: 6px;
-$mobile-menu-tab-line-height: 2.1875rem;
-$ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
+$_border-width-1: 1px;
+$_border-width-2: 2px;
+$_border-width-6: 6px;
+$_mobile-menu-tab-line-height: 2.1875rem;
+$ontario-header-menu-tabs-link-font-size: globalFunctions.px-to-rem(18);
 
 // Shared mixins
-@mixin menu-list-styles {
+@mixin _menu-list-styles {
 	list-style: none;
 	padding: spacing.$spacing-2 spacing.$spacing-0;
 	margin: spacing.$spacing-0;
-	border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 }
 
-@mixin menu-list-item-styles {
-	border-top: $border-width-1 solid colours.$ontario-greyscale-20;
+@mixin _menu-list-item-styles {
+	border-top: $_border-width-1 solid colours.$ontario-greyscale-20;
 	padding: spacing.$spacing-0;
 	margin-bottom: spacing.$spacing-0;
 
 	&:last-of-type {
-		border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+		border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 	}
 }
 
-@mixin menu-link-base-styles {
+@mixin _menu-link-base-styles {
 	color: colours.$ontario-colour-black;
-	font-size: $ontario-header-overflow-menu-link-font-size;
+	font-size: $ontario-header-menu-tabs-link-font-size;
 	font-weight: fontWeights.$ontario-font-weights-semi-bold;
 	font-family: fonts.$ontario-font-open-sans;
 	text-decoration: none;
@@ -50,7 +50,7 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 	display: block;
 }
 
-@mixin menu-link-interactive-styles {
+@mixin _menu-link-interactive-styles {
 	&:hover {
 		background-color: header.$navigation-link-bg--hover;
 
@@ -74,7 +74,7 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 	}
 
 	&.ontario-link--active {
-		border-left: $border-width-6 solid colours.$ontario-colour-black;
+		border-left: $_border-width-6 solid colours.$ontario-colour-black;
 		background-color: colours.$ontario-greyscale-5;
 	}
 }
@@ -105,7 +105,7 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 .ontario-mobile-menu__tabs {
 	display: flex;
 	background: colours.$ontario-colour-white;
-	border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 }
 
 .ontario-mobile-menu__tab {
@@ -118,7 +118,7 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 	border: none;
 	cursor: pointer;
 	color: colours.$ontario-colour-white;
-	line-height: $mobile-menu-tab-line-height;
+	line-height: $_mobile-menu-tab-line-height;
 
 	&:hover {
 		background: colours.$ontario-greyscale-60;
@@ -184,7 +184,7 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 
 .ontario-menu-list {
 	ul {
-		@include menu-list-styles;
+		@include _menu-list-styles;
 
 		@media screen and (min-width: breakpoints.$medium-breakpoint) {
 			border-bottom: none;
@@ -192,11 +192,11 @@ $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
 	}
 
 	li {
-		@include menu-list-item-styles;
+		@include _menu-list-item-styles;
 	}
 
 	a {
-		@include menu-link-base-styles;
-		@include menu-link-interactive-styles;
+		@include _menu-link-base-styles;
+		@include _menu-link-interactive-styles;
 	}
 }

--- a/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header-overflow-menu/ontario-header-overflow-menu.scss
@@ -11,35 +11,35 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSize;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/typography.variables';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 @use '../../styles/header.scss';
 
 // Variables
 $ontario-header-overflow-menu-link-font-size: globalFunctions.px-to-rem(18);
-$border-width-1: 1px;
-$border-width-6: 6px;
-$mobile-menu-tab-line-height: 2.1875rem;
+$_border-width-1: 1px;
+$_border-width-6: 6px;
+$_mobile-menu-tab-line-height: 2.1875rem;
 
 // Shared mixins
-@mixin menu-list-styles {
+@mixin _menu-list-styles {
 	list-style: none;
 	padding: spacing.$spacing-2 spacing.$spacing-0;
 	margin: spacing.$spacing-0;
-	border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 }
 
-@mixin menu-list-item-styles {
-	border-top: $border-width-1 solid colours.$ontario-greyscale-20;
+@mixin _menu-list-item-styles {
+	border-top: $_border-width-1 solid colours.$ontario-greyscale-20;
 	padding: spacing.$spacing-0;
 	margin-bottom: spacing.$spacing-0;
 
 	&:last-of-type {
-		border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+		border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 	}
 }
 
-@mixin menu-link-base-styles {
+@mixin _menu-link-base-styles {
 	color: colours.$ontario-colour-black;
 	font-size: $ontario-header-overflow-menu-link-font-size;
 	font-weight: fontWeights.$ontario-font-weights-semi-bold;
@@ -49,7 +49,7 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	display: block;
 }
 
-@mixin menu-link-interactive-styles {
+@mixin _menu-link-interactive-styles {
 	&:hover {
 		background-color: header.$navigation-link-bg--hover;
 
@@ -73,7 +73,7 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	}
 
 	&.ontario-link--active {
-		border-left: $border-width-6 solid colours.$ontario-colour-black;
+		border-left: $_border-width-6 solid colours.$ontario-colour-black;
 		background-color: colours.$ontario-greyscale-5;
 	}
 }
@@ -109,7 +109,7 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	}
 
 	ul {
-		@include menu-list-styles;
+		@include _menu-list-styles;
 
 		@media screen and (min-width: breakpoints.$medium-breakpoint) {
 			border-bottom: none;
@@ -117,18 +117,18 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	}
 
 	li {
-		@include menu-list-item-styles;
+		@include _menu-list-item-styles;
 	}
 
 	a {
-		@include menu-link-base-styles;
-		@include menu-link-interactive-styles;
+		@include _menu-link-base-styles;
+		@include _menu-link-interactive-styles;
 	}
 }
 
 .ontario-menu-list {
 	ul {
-		@include menu-list-styles;
+		@include _menu-list-styles;
 
 		@media screen and (min-width: breakpoints.$medium-breakpoint) {
 			border-bottom: none;
@@ -136,12 +136,12 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	}
 
 	li {
-		@include menu-list-item-styles;
+		@include _menu-list-item-styles;
 	}
 
 	a {
-		@include menu-link-base-styles;
-		@include menu-link-interactive-styles;
+		@include _menu-link-base-styles;
+		@include _menu-link-interactive-styles;
 	}
 }
 
@@ -191,7 +191,7 @@ $mobile-menu-tab-line-height: 2.1875rem;
 .ontario-mobile-menu__tabs {
 	display: flex;
 	background: colours.$ontario-colour-white;
-	border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 }
 
 .ontario-mobile-menu__tab {
@@ -204,7 +204,7 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	border: none;
 	cursor: pointer;
 	color: colours.$ontario-colour-white;
-	line-height: $mobile-menu-tab-line-height;
+	line-height: $_mobile-menu-tab-line-height;
 
 	&:hover {
 		background: colours.$ontario-greyscale-60;
@@ -233,16 +233,16 @@ $mobile-menu-tab-line-height: 2.1875rem;
 	}
 
 	ul {
-		@include menu-list-styles;
+		@include _menu-list-styles;
 	}
 
 	li {
-		@include menu-list-item-styles;
+		@include _menu-list-item-styles;
 	}
 
 	a {
-		@include menu-link-base-styles;
-		@include menu-link-interactive-styles;
+		@include _menu-link-base-styles;
+		@include _menu-link-interactive-styles;
 	}
 }
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-application-header.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-application-header.scss
@@ -10,8 +10,8 @@
 	focusPlaceholders;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/typography.variables';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/text-inputs.scss';
 @use '../../styles/header.scss';
@@ -23,7 +23,7 @@ $application-header-logo-height: 25px;
 $application-header-lang-toggle-font-size: globalFunctions.px-to-rem(16);
 $application-header-lang-toggle-line-height: globalFunctions.px-to-rem(22);
 $menu-button-icon-margin-right: 6px;
-$border-width-2: 2px;
+$_border-width-2: 2px;
 
 /* Ontario Application Header */
 .ontario-application-header {

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/ontario-header.scss
@@ -11,15 +11,15 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/line-heights.variables' as lineHeights;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/typography.variables';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/_grid.layout.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/5-layout/grid.layout';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 @use '../../styles/text-inputs.scss';
 @use '../../styles/header.scss';
 
 // Variables
-$border-width-1: 1px;
-$border-width-2: 2px;
-$border-width-6: 6px;
+$_border-width-1: 1px;
+$_border-width-2: 2px;
+$_border-width-6: 6px;
 $font-size-18: globalFunctions.px-to-rem(18);
 $ontario-search-padding: 7.2rem;
 $ontario-search-padding--mobile: 6.4rem;
@@ -59,7 +59,7 @@ $ontario-header-z-index: zIndex.$ontario-z-index-above-high;
 	list-style: none;
 	padding: spacing.$spacing-2 spacing.$spacing-0;
 	margin: spacing.$spacing-0;
-	border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 
 	@media screen and (min-width: breakpoints.$medium-breakpoint) {
 		border-bottom: none;
@@ -67,12 +67,12 @@ $ontario-header-z-index: zIndex.$ontario-z-index-above-high;
 }
 
 @mixin navigation-item-styles {
-	border-top: $border-width-1 solid colours.$ontario-greyscale-20;
+	border-top: $_border-width-1 solid colours.$ontario-greyscale-20;
 	padding: spacing.$spacing-0;
 	margin-bottom: spacing.$spacing-0;
 
 	&:last-of-type {
-		border-bottom: $border-width-1 solid colours.$ontario-greyscale-20;
+		border-bottom: $_border-width-1 solid colours.$ontario-greyscale-20;
 	}
 }
 
@@ -102,7 +102,7 @@ $ontario-header-z-index: zIndex.$ontario-z-index-above-high;
 	}
 
 	&.ontario-link--active {
-		border-left: $border-width-6 solid colours.$ontario-colour-black;
+		border-left: $_border-width-6 solid colours.$ontario-colour-black;
 		background-color: colours.$ontario-greyscale-5;
 	}
 }
@@ -249,7 +249,7 @@ $ontario-header-z-index: zIndex.$ontario-z-index-above-high;
 		@extend %ontario-header-button--with-outline;
 
 		&:hover {
-			border: $border-width-2 solid colours.$ontario-colour-white;
+			border: $_border-width-2 solid colours.$ontario-colour-white;
 			color: colours.$ontario-colour-white;
 		}
 
@@ -451,10 +451,6 @@ $ontario-header-z-index: zIndex.$ontario-z-index-above-high;
 			z-index: zIndex.$ontario-z-index-above-high;
 		}
 	}
-}
-
-.ontario-overlay {
-	@extend %ontario-overlay;
 }
 
 .ontario-icon-container {

--- a/packages/ontario-design-system-component-library/src/components/ontario-header/service-ontario-header.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-header/service-ontario-header.scss
@@ -181,10 +181,6 @@
 	}
 }
 
-.ontario-overlay {
-	@extend %ontario-overlay;
-}
-
 .ontario-navigation--open {
 	.ontario-service-subheader .ontario-header-button:first-of-type {
 		display: none;

--- a/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-input/ontario-input.scss
@@ -5,8 +5,8 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as
 	focusPlaceholders;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSizes;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/ontario-language-toggle.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-language-toggle/ontario-language-toggle.scss
@@ -8,7 +8,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as
 	focusPlaceholders;
 
-@forward 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 .ontario-language-toggler {
 	background-color: colours.$ontario-colour-black;

--- a/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-page-alert/ontario-page-alert.scss
@@ -3,7 +3,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/colours.variables' as colours;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/breakpoints.variables' as breakpoints;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/functions/global.functions' as globalFunctions;
-@forward 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
 
 $ontario-alert-link-focus: #6b0000;
 $ontario-alert-link-active: #280000;

--- a/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-search-box/ontario-search-box.scss
@@ -10,8 +10,8 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/functions/global.functions' as globalFunctions;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as
 	focusPlaceholders;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/ontario-step-indicator.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-step-indicator/ontario-step-indicator.scss
@@ -2,10 +2,10 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/global.variables' as globalVariables;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/spacing.variables' as spacing;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/breakpoints.variables' as breakpoints;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
 @use '../ontario-button/ontario-button.scss';
 
-$ontario-icon-size: 24px;
+$_ontario-icon-size: 24px;
 
 .ontario-step-indicator {
 	margin-bottom: spacing.$spacing-7;
@@ -56,8 +56,8 @@ $ontario-icon-size: 24px;
 	.ontario-icon {
 		margin: spacing.$spacing-0 math.div(spacing.$spacing-3, 2) spacing.$spacing-0 spacing.$spacing-0;
 		padding: spacing.$spacing-0;
-		min-width: $ontario-icon-size;
-		min-height: $ontario-icon-size;
+		min-width: $_ontario-icon-size;
+		min-height: $_ontario-icon-size;
 	}
 }
 

--- a/packages/ontario-design-system-component-library/src/components/ontario-summary-list-item/ontario-summary-list-item.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-summary-list-item/ontario-summary-list-item.scss
@@ -6,7 +6,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSizes;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/functions/global.functions' as globalFunctions;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as placeholders;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 :host {
 	display: block;

--- a/packages/ontario-design-system-component-library/src/components/ontario-summary-list/ontario-summary-list.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-summary-list/ontario-summary-list.scss
@@ -7,7 +7,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSizes;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/functions/global.functions' as globalFunctions;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as placeholders;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 :host {
 	display: block;

--- a/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.scss
+++ b/packages/ontario-design-system-component-library/src/components/ontario-textarea/ontario-textarea.scss
@@ -5,8 +5,8 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/2-tools/placeholder/focus.placeholders' as
 	focusPlaceholders;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/font-sizes.variables' as fontSizes;
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/_global.elements.scss';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/4-elements/global.elements';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 @use '../../styles/fieldsets.scss';
 @use '../../styles/labels.scss';

--- a/packages/ontario-design-system-component-library/src/styles/header.scss
+++ b/packages/ontario-design-system-component-library/src/styles/header.scss
@@ -10,7 +10,7 @@
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/z-index.variables' as zIndex;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/line-heights.variables' as lineHeights;
 @use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/1-variables/typography.variables';
-@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/_visibility.overrides.scss';
+@use 'pkg:@ongov/ontario-design-system-global-styles/styles/scss/7-overrides/visibility.overrides';
 
 $box-shadow-blur-radius-12: 12px;
 $font-size-18: globalFunctions.px-to-rem(18);
@@ -78,6 +78,12 @@ $header-height: globalFunctions.px-to-rem(50);
 	width: globalVariables.$full-width;
 	height: globalVariables.$full-width;
 	z-index: zIndex.$ontario-z-index-above-medium;
+}
+
+// Defined once here (rather than in each consumer) since `@extend` can't reliably
+// target this placeholder from multiple stylesheets that share this module.
+.ontario-overlay {
+	@extend %ontario-overlay;
 }
 
 %ontario-header-button {

--- a/packages/ontario-design-system-global-styles/README.md
+++ b/packages/ontario-design-system-global-styles/README.md
@@ -86,7 +86,7 @@ The `@use` rule loads mixins, functions, and variables from other Sass styleshee
 
 ### Exports map maintenance
 
-This package relies on `package.json` `exports` to expose compiled CSS and SCSS entry points. If the `dist/styles` folder structure changes, update the `exports` map in `package.json` to keep `pkg:` imports and direct style imports working as expected.
+This package relies on `package.json` `exports` to expose compiled CSS and SCSS entry points. `pnpm run exports:generate` (part of `build`) regenerates a canonical, extensionless key for every SCSS partial. Don't add wildcard entries like `./styles/scss/1-variables/*` back in — Dart Sass's `NodePackageImporter` can't tell those apart from the canonical keys and throws an ambiguous resolution error.
 
 Example `exports` entries for common style paths:
 
@@ -101,7 +101,7 @@ Example `exports` entries for common style paths:
 		},
 		"./styles/css/compiled/ontario-theme.min.css": "./dist/styles/css/compiled/ontario-theme.min.css",
 		"./styles/scss/theme.scss": "./dist/styles/scss/theme.scss",
-		"./styles/scss/1-variables/*": "./dist/styles/scss/1-variables/*"
+		"./styles/scss/1-variables/global.variables": "./dist/styles/scss/1-variables/_global.variables.scss"
 	}
 }
 ```

--- a/packages/ontario-design-system-global-styles/package.json
+++ b/packages/ontario-design-system-global-styles/package.json
@@ -95,16 +95,7 @@
 		"./styles/scss/6-components/all.component": "./dist/styles/scss/6-components/_all.component.scss",
 		"./styles/scss/6-components/buttons.component": "./dist/styles/scss/6-components/_buttons.component.scss",
 		"./styles/scss/7-overrides/spacing.overrides": "./dist/styles/scss/7-overrides/_spacing.overrides.scss",
-		"./styles/scss/7-overrides/visibility.overrides": "./dist/styles/scss/7-overrides/_visibility.overrides.scss",
-		"./styles/scss/1-variables/*": "./dist/styles/scss/1-variables/*",
-		"./styles/scss/2-tools/functions/*": "./dist/styles/scss/2-tools/functions/*",
-		"./styles/scss/2-tools/mixins/*": "./dist/styles/scss/2-tools/mixins/*",
-		"./styles/scss/2-tools/placeholder/*": "./dist/styles/scss/2-tools/placeholder/*",
-		"./styles/scss/3-generics/*": "./dist/styles/scss/3-generics/*",
-		"./styles/scss/4-elements/*": "./dist/styles/scss/4-elements/*",
-		"./styles/scss/5-layout/*": "./dist/styles/scss/5-layout/*",
-		"./styles/scss/6-components/*": "./dist/styles/scss/6-components/*",
-		"./styles/scss/7-overrides/*": "./dist/styles/scss/7-overrides/*"
+		"./styles/scss/7-overrides/visibility.overrides": "./dist/styles/scss/7-overrides/_visibility.overrides.scss"
 	},
 	"sass": "dist/styles/scss/theme.scss"
 }

--- a/packages/ontario-design-system-global-styles/scripts/generate-scss-exports.mjs
+++ b/packages/ontario-design-system-global-styles/scripts/generate-scss-exports.mjs
@@ -37,19 +37,6 @@ function logStep(label, message, colour = ANSI.blue) {
 	console.log(`${colour}[${label}]${ANSI.reset} ${message}`);
 }
 
-// Wildcard exports for source-facing SCSS imports.
-const STYLE_WILDCARD_EXPORTS = [
-	'./styles/scss/1-variables/*',
-	'./styles/scss/2-tools/functions/*',
-	'./styles/scss/2-tools/mixins/*',
-	'./styles/scss/2-tools/placeholder/*',
-	'./styles/scss/3-generics/*',
-	'./styles/scss/4-elements/*',
-	'./styles/scss/5-layout/*',
-	'./styles/scss/6-components/*',
-	'./styles/scss/7-overrides/*',
-];
-
 /**
  * Recursively collects underscore-prefixed `.scss` partial file paths from a root directory.
  *
@@ -140,12 +127,11 @@ function buildOrderedExports(existingExports, extensionlessSpecifiers) {
 		);
 	}
 
-	for (const wildcardKey of STYLE_WILDCARD_EXPORTS) {
-		setExport(wildcardKey, wildcardKey.replace('./styles/scss', DIST_SCSS_ROOT));
-	}
-
 	for (const [key, value] of Object.entries(existingExports)) {
-		if (!consumedKeys.has(key) && !key.startsWith('./dist/styles/scss/')) {
+		// Drop legacy wildcard SCSS exports: they overlap canonical keys above and cause
+		// Dart Sass's NodePackageImporter to report ambiguous "multiple potential resolutions".
+		const isLegacyStyleWildcard = key.startsWith('./styles/scss/') && key.endsWith('/*');
+		if (!consumedKeys.has(key) && !key.startsWith('./dist/styles/scss/') && !isLegacyStyleWildcard) {
 			setExport(key, value);
 		}
 	}


### PR DESCRIPTION
## Summary
The Complete Styles package couldn't be used in the Angular application. The ticket called out an issue with file-watching in the build process, and that's real, but tracking it down also surfaced a few build/Sass bugs that were the actual reason Angular couldn't compile the package at all. All of it needed fixing to actually resolve the Angular issue, so it's included here together.

## Changes
- **Why Angular couldn't compile it at all**
  - Complete Styles' package exports had two entries that could both match the same file, which Angular's Sass compiler couldn't resolve ("ambiguous resolution" error).
  - The package's own build wasn't catching Sass errors, so it kept reporting success even when the compiled output was broken or stale — this hid the export bug above, plus a few Sass naming clashes between components, from ever being caught.
  - Fixed a handful of components (mostly the header family, plus back-button/step-indicator) with accidentally clashing Sass variable and mixin names, and removed some redundant re-exports.
- **File-watching, as described in the ticket**
  - The package's `scss` script pointed at a folder structure that hasn't existed since it was reorganized, so it failed immediately.
  - Its `watch` task only watched its own `src/`, which the build deletes as its last step, so it never had anything to watch.
  - Rewired `watch` to follow the real upstream sources (global-styles and component-library) and rebuild automatically when they change.
- Updated the global-styles README to match the corrected exports.

## Testing
- Rebuilt Complete Styles and confirmed the ambiguous export and build swallowing issues are gone
- Verified `pnpm run watch` does a real build and rebuilds automatically when an upstream source file changes
- Manually wired Complete Styles into an Angular POC and confirmed it now compiles and renders correctly, resolving the reported issue
- Also spot-checked the same setup in React while testing — not part of this ticket, but confirming it still renders correctly too